### PR TITLE
srl_encoder.c: fix bug when sort_keys,stringify_unknown are combined

### DIFF
--- a/Perl/Encoder/srl_encoder.c
+++ b/Perl/Encoder/srl_encoder.c
@@ -257,7 +257,6 @@ srl_build_encoder_struct(pTHX_ HV *opt)
 
         svp = hv_fetchs(opt, "sort_keys", 0);
         if ( svp && SvTRUE(*svp) ) {
-            undef_unknown = 1;
             enc->flags |= SRL_F_SORT_KEYS;
         }
 

--- a/Perl/Encoder/t/021_sort_keys_option.t
+++ b/Perl/Encoder/t/021_sort_keys_option.t
@@ -1,0 +1,10 @@
+#!perl
+use strict;
+use warnings;
+use Test::More tests => 1;
+use Sereal::Encoder qw(encode_sereal);
+
+eval { encode_sereal(\1, { sort_keys => 1, stringify_unknown => 1 }); };
+ok !$@, "We shouldn't die on sort_keys combined with stringify_unknown";
+
+


### PR DESCRIPTION
Bug introduced in commit 67e3d11a7239209e154c6b3b0ab4d192257f36af.
Looks like a copy/paste error.

Variable undef_unknown mistakenly set to 1 when option 'sort_keys'
is true. If 'stringify_unknown' is also true then we croak with
the message
  'undef_unknown' and 'stringify_unknown' options are mutually exclusive

The fix simply doesn't assign undef_unknown=1 when 'sort_keys' is true.
A test case t/021_sort_keys_option.t is also added.
