### PR TITLE
New decoder flag: nobless_objects

### DIFF
--- a/Perl/Decoder/lib/Sereal/Decoder.pm
+++ b/Perl/Decoder/lib/Sereal/Decoder.pm
@@ -97,7 +97,7 @@ desirable for robustness. See the section C<ROBUSTNESS> below.
 If set, the decoder will refuse deserializing any objects in the input stream and
 instead throw and exception. Defaults to off. See the section C<ROBUSTNESS> below.
 
-=head3 nobless_objects
+=head3 no_bless_objects
 
 If set, the decoder will deserialize any objects in the input stream but without
 blessing them. Defaults to off. See the section C<ROBUSTNESS> below.
@@ -241,7 +241,7 @@ trivial to craft a Sereal document that causes this behaviour.
 Finally, deserializing proper objects is potentially a problem because
 classes can define a destructor. Thus, the data fed to the decoder can
 cause the (deferred) execution of any destructor in your application.
-That's why the C<refuse_objects> option exists and what the C<nobless_objects>
+That's why the C<refuse_objects> option exists and what the C<no_bless_objects>
 can be used for as well. Later on, we may or may not provide a facility to
 whitelist classes.
 

--- a/Perl/Decoder/srl_decoder.c
+++ b/Perl/Decoder/srl_decoder.c
@@ -173,8 +173,8 @@ srl_build_decoder_struct(pTHX_ HV *opt)
         if ( (svp = hv_fetchs(opt, "refuse_objects", 0)) && SvTRUE(*svp))
             SRL_DEC_SET_OPTION(dec, SRL_F_DECODER_REFUSE_OBJECTS);
 
-        if ( (svp = hv_fetchs(opt, "nobless_objects", 0)) && SvTRUE(*svp))
-            SRL_DEC_SET_OPTION(dec, SRL_F_DECODER_NOBLESS_OBJECTS);
+        if ( (svp = hv_fetchs(opt, "no_bless_objects", 0)) && SvTRUE(*svp))
+            SRL_DEC_SET_OPTION(dec, SRL_F_DECODER_NO_BLESS_OBJECTS);
 
         if ( (svp = hv_fetchs(opt, "validate_utf8", 0)) && SvTRUE(*svp))
             SRL_DEC_SET_OPTION(dec, SRL_F_DECODER_VALIDATE_UTF8);
@@ -403,7 +403,7 @@ srl_read_header(pTHX_ srl_decoder_t *dec)
 SRL_STATIC_INLINE void
 srl_finalize_structure(pTHX_ srl_decoder_t *dec)
 {
-    int nobless = SRL_DEC_HAVE_OPTION(dec, SRL_F_DECODER_NOBLESS_OBJECTS);
+    int nobless = SRL_DEC_HAVE_OPTION(dec, SRL_F_DECODER_NO_BLESS_OBJECTS);
     if (dec->weakref_av)
         av_clear(dec->weakref_av);
     if (dec->ref_stashes) {
@@ -890,7 +890,7 @@ srl_read_objectv(pTHX_ srl_decoder_t *dec, SV* into)
     stash= PTABLE_fetch(dec->ref_stashes, (void *)ofs);
     if (stash == NULL)
         SRL_ERROR("Corrupted packet. OBJECTV used without preceding OBJECT to define classname");
-    if (!SRL_DEC_HAVE_OPTION(dec, SRL_F_DECODER_NOBLESS_OBJECTS))
+    if (!SRL_DEC_HAVE_OPTION(dec, SRL_F_DECODER_NO_BLESS_OBJECTS))
         sv_bless(into, stash);
 #endif
 
@@ -999,7 +999,7 @@ srl_read_object(pTHX_ srl_decoder_t *dec, SV* into)
 
 #if USE_588_WORKAROUND
     /* See 'define USE_588_WORKAROUND' above for a discussion of what this does. */
-    if (!SRL_DEC_HAVE_OPTION(dec, SRL_F_DECODER_NOBLESS_OBJECTS))
+    if (!SRL_DEC_HAVE_OPTION(dec, SRL_F_DECODER_NO_BLESS_OBJECTS))
         sv_bless(into, stash);
 #endif
 }

--- a/Perl/Decoder/srl_decoder.h
+++ b/Perl/Decoder/srl_decoder.h
@@ -83,7 +83,7 @@ void srl_decoder_destructor_hook(pTHX_ void *p);
 /* Persistent flag: Make the decoder validate UTT8 strings */
 #define SRL_F_DECODER_VALIDATE_UTF8 64UL
 /* Persistent flag: Make the encoder forget to bless */
-#define SRL_F_DECODER_NOBLESS_OBJECTS 128UL
+#define SRL_F_DECODER_NO_BLESS_OBJECTS 128UL
 
 #define SRL_DEC_HAVE_OPTION(dec, flag_num) ((dec)->flags & flag_num)
 #define SRL_DEC_SET_OPTION(dec, flag_num) ((dec)->flags |= flag_num)

--- a/Perl/Decoder/t/110_nobless.t
+++ b/Perl/Decoder/t/110_nobless.t
@@ -26,7 +26,7 @@ else {
 
     # do not bless anything
     {
-        my $dec = Sereal::Decoder->new({ nobless_objects => 1 });
+        my $dec = Sereal::Decoder->new({ no_bless_objects => 1 });
         my $data = $dec->decode( $blob );
 
         ok( ref( $data ) && !blessed( $data ), 'reference without class' );

--- a/Perl/Encoder/lib/Sereal/Encoder.pm
+++ b/Perl/Encoder/lib/Sereal/Encoder.pm
@@ -115,11 +115,11 @@ This can be important because blessed references can mean executing
 a destructor on a remote system or generally executing code based on
 data.
 
-See also C<nobless_objects> to skip the blessing of objects.
+See also C<no_bless_objects> to skip the blessing of objects.
 When both flags are set, C<croak_on_bless> has a higher precedence then
-C<nobless_objects>.
+C<no_bless_objects>.
 
-=head3 nobless_objects
+=head3 no_bless_objects
 
 If this option is set, then the encoder will serialize blessed references
 without the bless information and provide plain data structures instead.

--- a/Perl/Encoder/srl_encoder.c
+++ b/Perl/Encoder/srl_encoder.c
@@ -253,9 +253,9 @@ srl_build_encoder_struct(pTHX_ HV *opt)
         if ( svp && SvTRUE(*svp) )
             enc->flags |= SRL_F_CROAK_ON_BLESS;
 
-        svp = hv_fetchs(opt, "nobless_objects", 0);
+        svp = hv_fetchs(opt, "no_bless_objects", 0);
         if ( svp && SvTRUE(*svp) )
-            enc->flags |= SRL_F_NOBLESS_OBJECTS;
+            enc->flags |= SRL_F_NO_BLESS_OBJECTS;
 
         svp = hv_fetchs(opt, "snappy", 0);
         if ( svp && SvTRUE(*svp) )
@@ -1059,7 +1059,7 @@ srl_dump_sv(pTHX_ srl_encoder_t *enc, SV *src)
     UV weakref_ofs= 0;              /* preserved between loops */
     SSize_t ref_rewrite_pos= 0;      /* preserved between loops - note SSize_t is a perl define */
     assert(src);
-    int nobless = SRL_ENC_HAVE_OPTION(enc, SRL_F_NOBLESS_OBJECTS);
+    int nobless = SRL_ENC_HAVE_OPTION(enc, SRL_F_NO_BLESS_OBJECTS);
 
     if (++enc->recursion_depth == enc->max_recursion_depth) {
         croak("Hit maximum recursion depth (%lu), aborting serialization",

--- a/Perl/Encoder/srl_encoder.h
+++ b/Perl/Encoder/srl_encoder.h
@@ -85,8 +85,8 @@ void srl_dump_data_structure(pTHX_ srl_encoder_t *enc, SV *src);
 #define SRL_F_DEDUPE_STRINGS                 0x00400UL
 
 /* If set in flags, then we serialize objects without class information.
- * Corresponds to the 'nobless_objects' flag found in the Decoder. */
-#define SRL_F_NOBLESS_OBJECTS                0x00800UL
+ * Corresponds to the 'no_bless_objects' flag found in the Decoder. */
+#define SRL_F_NO_BLESS_OBJECTS                0x00800UL
 
 /* Set while the encoder is in active use / dirty */
 #define SRL_OF_ENCODER_DIRTY                 1UL

--- a/Perl/Encoder/t/110_nobless.t
+++ b/Perl/Encoder/t/110_nobless.t
@@ -25,7 +25,7 @@ else {
 
     # do not bless anything
     {
-        my $enc = Sereal::Encoder->new({ nobless_objects => 1 });
+        my $enc = Sereal::Encoder->new({ no_bless_objects => 1 });
         my $blob = $enc->encode( $object );
 
         my $data = $dec->decode( $blob );


### PR DESCRIPTION
This change provides a new encoder flag to allow deserialization without blessing contained objects in order to get pure data structures.

It is a relatively small patch, with test and documentation.
