### PR TITLE
[ruby] freeze and thaw nested classes correctly

### DIFF
--- a/ruby/ext/sereal/decode.c
+++ b/ruby/ext/sereal/decode.c
@@ -245,7 +245,7 @@ static VALUE s_read_object_freeze(sereal_t *s, u8 tag) {
     MUST_BE_SOMETHING(s_klass,T_STRING);
 
     // hash it?
-    VALUE klass = rb_const_get(rb_cObject, rb_intern(RSTRING_PTR(s_klass)));
+    VALUE klass = rb_path_to_class(s_klass);
     if (!rb_obj_respond_to(klass,THAW,0))
         s_raise(s,rb_eTypeError,"class: %s does not respond to THAW",
                 rb_obj_classname(s_klass));

--- a/ruby/ext/sereal/encode.c
+++ b/ruby/ext/sereal/encode.c
@@ -180,14 +180,14 @@ static VALUE s_copy_or_keep_in_mind(sereal_t *s, VALUE object) {
 */
 static void s_append_object(sereal_t *s, VALUE object) {
     if (s->flags & __THAW && rb_obj_respond_to(object,FREEZE,0)) {
-        VALUE klass = rb_class_name(CLASS_OF(object));
+        VALUE klass = rb_class_path(CLASS_OF(object));
         VALUE copy = s_copy_or_keep_in_mind(s,klass);
         if (copy != Qnil) {
             s_append_u8(s,SRL_HDR_OBJECTV_FREEZE);
             s_append_copy(s,copy);
         } else {
             s_append_u8(s,SRL_HDR_OBJECT_FREEZE);
-            s_append_rb_string(s,rb_class_name(CLASS_OF(object)));
+            s_append_rb_string(s,klass);
         }
         VALUE frozen = rb_funcall(object,FREEZE,1,ID2SYM(SEREAL));
         if (TYPE(frozen) != T_ARRAY)

--- a/ruby/test/test_sereal.rb
+++ b/ruby/test/test_sereal.rb
@@ -20,6 +20,19 @@ class ZXCFile
   end
 end
 class ZXCFREEZE
+  class InnerClass
+    attr_accessor :value
+    def initialize(value)
+      @value = value
+    end
+    def FREEZE(serializer)
+      [value]
+    end
+    def self.THAW(serializer,*a)
+      new(*a)
+    end
+  end
+
   attr_accessor :z,:x,:c,:serializer
   def initialize(z,x,c)
     @z = z
@@ -78,6 +91,13 @@ class Test::Unit::TestCase
     assert_not_equal(x[0].object_id,x[1].object_id)
     assert_equal(x[0].object_id,x[2].object_id)
     assert Sereal.encode(a,Sereal::COPY|Sereal::REF).length < Sereal.encode(a,Sereal::REF).length
+  end
+
+  def test_nested_class_thaw
+    original = ZXCFREEZE::InnerClass.new("hello")
+    recoded = Sereal.decode(Sereal.encode(original,Sereal::THAW),Sereal::THAW)
+    assert_equal(ZXCFREEZE::InnerClass, recoded.class)
+    assert_equal(original.value,recoded.value)
   end
 
   def test_thaw


### PR DESCRIPTION
correctly determine class to thaw, since rb_const_get on rb_cObject does not work with nested class strings like "ZXCFREEZE::InnerClass"
