### PR TITLE
[ruby] make the __COPY and __THAW flags have different values

### DIFF
--- a/ruby/ext/sereal/sereal.h
+++ b/ruby/ext/sereal/sereal.h
@@ -114,7 +114,7 @@ extern VALUE SerealPerlObject;
 #define __NOT_MINE      16
 #define __STREAM        32
 #define __THAW          64
-#define __COPY          64
+#define __COPY          128
 #define __ARGUMENT_FLAGS (__DEBUG|__THAW|__REF|__COPY)
 
 #define __MIN_SIZE      6


### PR DESCRIPTION
I'm not sure if this was intentional or a typo, but currently since the __COPY and __THAW flags have the same value, you instantly pay the performance penalty of __COPY if you turn on __THAW.  If this was intentional for some reason, feel free to just close this PR :)
