### PR TITLE
add set_readonly and set_readonly_scalars options

### DIFF
--- a/Perl/Decoder/lib/Sereal/Decoder.pm
+++ b/Perl/Decoder/lib/Sereal/Decoder.pm
@@ -189,6 +189,15 @@ If set to a true value then this any undef value to be deserialized as
 PL_sv_undef. This may change the structure of the data structure being
 dumped, do not enable this unless you know what you are doing.
 
+=head3 set_readonly
+
+If set to a true value then the output will be completely readonly (deeply).
+
+=head3 set_readonly_scalars
+
+If set to a true value then scalars in the output will be readonly (deeply).
+References won't be readonly.
+
 =head1 INSTANCE METHODS
 
 =head2 decode

--- a/Perl/Decoder/srl_decoder.c
+++ b/Perl/Decoder/srl_decoder.c
@@ -268,6 +268,14 @@ srl_build_decoder_struct(pTHX_ HV *opt)
         if ( (svp = hv_fetchs(opt, "use_undef", 0)) && SvTRUE(*svp))
             SRL_DEC_SET_OPTION(dec,SRL_F_DECODER_USE_UNDEF);
 
+        /* check if they want us to set all SVs readonly. */
+        if ( (svp = hv_fetchs(opt, "set_readonly", 0)) && SvTRUE(*svp))
+            SRL_DEC_SET_OPTION(dec, SRL_F_DECODER_SET_READONLY);
+
+        /* check if they want us to set normal scalars readonly. */
+        if ( (svp = hv_fetchs(opt, "set_readonly_scalars", 0)) && SvTRUE(*svp))
+            SRL_DEC_SET_OPTION(dec, SRL_F_DECODER_SET_READONLY_SCALARS);
+
     }
 
     return dec;
@@ -715,6 +723,7 @@ SRL_STATIC_INLINE void
 srl_finalize_structure(pTHX_ srl_decoder_t *dec)
 {
     int nobless = SRL_DEC_HAVE_OPTION(dec, SRL_F_DECODER_NO_BLESS_OBJECTS);
+
     if (dec->weakref_av)
         av_clear(dec->weakref_av);
     if (dec->ref_stashes) {
@@ -747,8 +756,17 @@ srl_finalize_structure(pTHX_ srl_decoder_t *dec)
 #if USE_588_WORKAROUND
                         /* was blessed early, don't rebless */
 #else
-                        if (!nobless)
-                            sv_bless(obj, stash);
+                        if (!nobless) {
+                            if ( SRL_DEC_HAVE_OPTION(dec, SRL_F_DECODER_READONLY_FLAGS) && SvREADONLY(SvRV(obj))) {
+                                /* the referenced scalar was readonly, temporary 
+                                   set it rw to bless its reference */
+                                SvREADONLY_off(SvRV(obj));
+                                sv_bless(obj, stash);
+                                SvREADONLY_on(SvRV(obj));
+                            } else {
+                                sv_bless(obj, stash);
+                            }
+                        }
 #endif
                     } else {
                         PTABLE_iter_free(it);
@@ -1790,6 +1808,7 @@ srl_read_single_value(pTHX_ srl_decoder_t *dec, SV* into)
 {
     STRLEN len;
     U8 tag;
+    int is_ref = 0;
     if (++dec->recursion_depth > dec->max_recursion_depth) {
         SRL_ERRORf1("Reached recursion limit (%lu) during deserialization",
                 (unsigned long)dec->max_recursion_depth);
@@ -1823,39 +1842,41 @@ srl_read_single_value(pTHX_ srl_decoder_t *dec, SV* into)
     else
     if ( IS_SRL_HDR_HASHREF(tag) ) {
         srl_read_hash(aTHX_ dec, into, tag);
+        is_ref = 1;
     }
     else
     if ( IS_SRL_HDR_ARRAYREF(tag) ) {
         srl_read_array(aTHX_ dec, into, tag);
+        is_ref = 1;
     }
     else {
         switch (tag) {
-            case SRL_HDR_VARINT:        srl_read_varint(aTHX_ dec, into);           break;
-            case SRL_HDR_ZIGZAG:        srl_read_zigzag(aTHX_ dec, into);           break;
+            case SRL_HDR_VARINT:        srl_read_varint(aTHX_ dec, into);                 break;
+            case SRL_HDR_ZIGZAG:        srl_read_zigzag(aTHX_ dec, into);                 break;
 
-            case SRL_HDR_FLOAT:         srl_read_float(aTHX_ dec, into);            break;
-            case SRL_HDR_DOUBLE:        srl_read_double(aTHX_ dec, into);           break;
-            case SRL_HDR_LONG_DOUBLE:   srl_read_long_double(aTHX_ dec, into);      break;
+            case SRL_HDR_FLOAT:         srl_read_float(aTHX_ dec, into);                  break;
+            case SRL_HDR_DOUBLE:        srl_read_double(aTHX_ dec, into);                 break;
+            case SRL_HDR_LONG_DOUBLE:   srl_read_long_double(aTHX_ dec, into);            break;
 
-            case SRL_HDR_TRUE:          sv_setsv(into, &PL_sv_yes);                 break;
-            case SRL_HDR_FALSE:         sv_setsv(into, &PL_sv_no);                  break;
+            case SRL_HDR_TRUE:          sv_setsv(into, &PL_sv_yes);                       break;
+            case SRL_HDR_FALSE:         sv_setsv(into, &PL_sv_no);                        break;
             case SRL_HDR_CANONICAL_UNDEF: /* fallthrough */
-            case SRL_HDR_UNDEF:         sv_setsv(into, &PL_sv_undef);               break;
-            case SRL_HDR_BINARY:        srl_read_string(aTHX_ dec, 0, into);        break;
-            case SRL_HDR_STR_UTF8:      srl_read_string(aTHX_ dec, 1, into);        break;
+            case SRL_HDR_UNDEF:         sv_setsv(into, &PL_sv_undef);                     break;
+            case SRL_HDR_BINARY:        srl_read_string(aTHX_ dec, 0, into);              break;
+            case SRL_HDR_STR_UTF8:      srl_read_string(aTHX_ dec, 1, into);              break;
 
-            case SRL_HDR_WEAKEN:        srl_read_weaken(aTHX_ dec, into);           break;
-            case SRL_HDR_REFN:          srl_read_refn(aTHX_ dec, into);             break;
-            case SRL_HDR_REFP:          srl_read_refp(aTHX_ dec, into);             break;
+            case SRL_HDR_WEAKEN:        srl_read_weaken(aTHX_ dec, into);       is_ref=1; break;
+            case SRL_HDR_REFN:          srl_read_refn(aTHX_ dec, into);         is_ref=1; break;
+            case SRL_HDR_REFP:          srl_read_refp(aTHX_ dec, into);         is_ref=1; break;
             case SRL_HDR_OBJECT_FREEZE:
-            case SRL_HDR_OBJECT:        srl_read_object(aTHX_ dec, into, tag);      break;
+            case SRL_HDR_OBJECT:        srl_read_object(aTHX_ dec, into, tag);  is_ref=1; break;
             case SRL_HDR_OBJECTV_FREEZE:
-            case SRL_HDR_OBJECTV:       srl_read_objectv(aTHX_ dec, into, tag);     break;
-            case SRL_HDR_COPY:          srl_read_copy(aTHX_ dec, into);             break;
-            case SRL_HDR_EXTEND:        srl_read_extend(aTHX_ dec, into);           break;
-            case SRL_HDR_HASH:          srl_read_hash(aTHX_ dec, into, 0);          break;
-            case SRL_HDR_ARRAY:         srl_read_array(aTHX_ dec, into, 0);         break;
-            case SRL_HDR_REGEXP:        srl_read_regexp(aTHX_ dec, into);           break;
+            case SRL_HDR_OBJECTV:       srl_read_objectv(aTHX_ dec, into, tag); is_ref=1; break;
+            case SRL_HDR_COPY:          srl_read_copy(aTHX_ dec, into);                   break;
+            case SRL_HDR_EXTEND:        srl_read_extend(aTHX_ dec, into);                 break;
+            case SRL_HDR_HASH:          srl_read_hash(aTHX_ dec, into, 0);                break;
+            case SRL_HDR_ARRAY:         srl_read_array(aTHX_ dec, into, 0);               break;
+            case SRL_HDR_REGEXP:        srl_read_regexp(aTHX_ dec, into);                 break;
 
             case SRL_HDR_PAD:           /* no op */
                 while (BUF_NOT_DONE(dec) && *dec->pos == SRL_HDR_PAD)
@@ -1866,6 +1887,12 @@ srl_read_single_value(pTHX_ srl_decoder_t *dec, SV* into)
                 SRL_ERROR_UNEXPECTED(dec,tag, " single value");
             break;
         }
+    }
+
+    /* they want us to set all SVs readonly, or only the non-ref */
+    if (  SRL_DEC_HAVE_OPTION(dec, SRL_F_DECODER_SET_READONLY) ||
+          (SRL_DEC_HAVE_OPTION(dec, SRL_F_DECODER_SET_READONLY_SCALARS) && !is_ref) ) {
+        SvREADONLY_on(into);
     }
 
     dec->recursion_depth--;

--- a/Perl/Decoder/srl_decoder.h
+++ b/Perl/Decoder/srl_decoder.h
@@ -126,9 +126,14 @@ void srl_decoder_destructor_hook(pTHX_ void *p);
 #define SRL_F_DECODER_ALIAS_VARINT              0x00002000UL
 /* Persistent flag: use PL_sv_undef as many places as possible */
 #define SRL_F_DECODER_USE_UNDEF                 0x00004000UL
+/* Persistent flag: set all SV readonly */
+#define SRL_F_DECODER_SET_READONLY              0x00008000UL
+/* Persistent flag: set non-ref SV readonly */
+#define SRL_F_DECODER_SET_READONLY_SCALARS      0x00010000UL
 
 
 #define SRL_F_DECODER_ALIAS_CHECK_FLAGS   ( SRL_F_DECODER_ALIAS_SMALLINT | SRL_F_DECODER_ALIAS_VARINT | SRL_F_DECODER_USE_UNDEF )
+#define SRL_F_DECODER_READONLY_FLAGS   ( SRL_F_DECODER_SET_READONLY | SRL_F_DECODER_SET_READONLY_SCALARS )
 
 #define SRL_DEC_HAVE_OPTION(dec, flag_num) ((dec)->flags & flag_num)
 #define SRL_DEC_SET_OPTION(dec, flag_num) ((dec)->flags |= flag_num)

--- a/Perl/Decoder/t/080_set_readonly.t
+++ b/Perl/Decoder/t/080_set_readonly.t
@@ -1,0 +1,85 @@
+use strict;
+use warnings;
+
+use Sereal::Decoder;
+use Test::More;
+use File::Spec;
+use lib File::Spec->catdir(qw(t lib));
+BEGIN {
+    lib->import('lib')
+        if !-d 't';
+}
+use Sereal::TestSet qw(:all);
+
+my @tests= (
+    [ set_readonly => 1  ],
+);
+
+if (have_encoder_and_decoder()) {
+    my $num_tests= 26;
+    plan tests => $num_tests;
+} else {
+    plan skip_all => 'Did not find right version of encoder';
+}
+
+my $foo = bless([ 1, 2, 3 ],"foo");
+
+my $struct= {
+    hashref => { a => [ "b", 5, bless({ foo => "bar"}, "SomeClass")] },
+    string => "foobar",
+    arrayref => [ "foobar" ],
+    blessed_arrayref => $foo,
+};
+
+foreach my $name ( keys %$struct ) {
+
+    local $_ = $struct->{$name};
+    my $enc = Sereal::Encoder->new;
+    my $dec = Sereal::Decoder->new( { set_readonly => 1 } );
+    my $dec2 = Sereal::Decoder->new( { set_readonly_scalars => 1 } );
+
+    my $got;
+    $dec->decode($enc->encode($_), $got);
+    my $got2;
+    $dec2->decode($enc->encode($_), $got2);
+
+    # undef the decoder to make sure if it blows up on DESTROY it does it before we test.
+    undef $dec;
+    undef $dec2;
+    undef $enc;
+
+    _recurse($got, '', $name, 0);
+    _recurse($got2, '', $name, 1);
+
+}
+
+sub _recurse {
+    my ($s, $path, $name, $scalars_only) = @_;
+
+    $scalars_only ||= 0;
+    my $should_be_readonly = $scalars_only ? !ref($s) : 1;
+    is(Internals::SvREADONLY($_[0]), $should_be_readonly,
+       "scalar_only: '$scalars_only'. We want ro: '$should_be_readonly'. struct: $name, path: $path"
+      );
+
+    my $ref = ref $s
+      or return;
+
+    if ($ref eq 'ARRAY' || $ref eq 'foo') { 
+        my $i = 0;
+        foreach (@$s) {
+            _recurse($_, $path . '->[' . $i . ']', $name, $scalars_only);
+        }
+    }
+    elsif ($ref eq 'HASH' || $ref eq 'SomeClass') {
+        foreach (keys %$s) {
+            _recurse($s->{$_}, $path . '->{' . $_ . '}', $name, $scalars_only);
+        }
+    } elsif ($ref eq 'SCALAR') {
+        _recurse($$s, '${' . $path . '}', $name, $scalars_only);
+    } else {
+        die "unknown ref value '$ref'";
+    }
+}
+
+

--- a/Perl/Decoder/t/210_bulk_readonly.t
+++ b/Perl/Decoder/t/210_bulk_readonly.t
@@ -1,0 +1,34 @@
+#!perl
+use strict;
+use warnings;
+use Sereal::Decoder;
+use Data::Dumper;
+use File::Spec;
+
+# These tests use an installed Decoder (or respectively Encoder) to do
+# bulk data testing.
+
+use lib File::Spec->catdir(qw(t lib));
+BEGIN {
+    lib->import('lib')
+        if !-d 't';
+}
+
+use Sereal::TestSet qw(:all);
+use Sereal::BulkTest qw(:all);
+use Test::More;
+
+my $ok = have_encoder_and_decoder();
+if (not $ok) {
+    plan skip_all => 'Did not find right version of encoder';
+}
+else {
+    my %opt = (
+        bench => scalar(grep /^--bench$/, @ARGV),
+    );
+    run_bulk_tests(%opt, decoder_options => { set_readonly => 1});
+}
+
+pass();
+done_testing();
+

--- a/Perl/shared/t/lib/Sereal/BulkTest.pm
+++ b/Perl/shared/t/lib/Sereal/BulkTest.pm
@@ -84,7 +84,7 @@ sub run_bulk_tests {
             my ($dump, $undump);
             my $ok= eval {
                 $dump = Sereal::Encoder::encode_sereal($_[0]);
-                $undump= Sereal::Decoder::decode_sereal($dump);
+                $undump= Sereal::Decoder::decode_sereal($dump, $opt{decoder_options} || {});
                 1;
             };
             my $err = $@ || 'Zombie error';
@@ -119,7 +119,7 @@ sub run_bulk_tests {
                     read_files(sub{return 1})
                 },
                 'decode_sereal' => sub{
-                    read_files(sub { return( decode_sereal($_[0]) ); }, 'sereal')
+                    read_files(sub { return( decode_sereal($_[0], $opt{decoder_options} || {} ) ); }, 'sereal')
                 },
                 'eval' => sub{
                     read_files(sub { return( eval $_[0] ); }, 'raw')

--- a/Perl/shared/t/lib/Sereal/TestSet.pm
+++ b/Perl/shared/t/lib/Sereal/TestSet.pm
@@ -718,6 +718,7 @@ sub run_roundtrip_tests {
             ['sort_keys',      { sort_keys        => 1 }, 2 ],
             ['dedupe_strings', { dedupe_strings   => 1 }, 2 ],
             ['freeze/thaw',    { freeze_callbacks => 1 }, 2 ],
+            ['readonly',       { set_readonly     => 1 }, 2 ],
         );
         for my $opt (@variants) {
             my ($name, $opts, $min_proto_v, $max_proto_v) = @$opt;


### PR DESCRIPTION
This adds a `set_readonly` and `set_readonly_scalars` options, to set the output structure readonly, deeply. The second option excludes references.

Reason for this code is that at $work, we need a way to protect users of deserealized structures against modifying it. Having this option avoids wasting time recursing on it.

This is a better re-implementation of #57 
