### PR TITLE
newUNOP(OP_CUSTOM, ...) fails assertions in debugging builds

### DIFF
--- a/Perl/Decoder/Decoder.xs
+++ b/Perl/Decoder/Decoder.xs
@@ -228,7 +228,8 @@ THX_ck_entersub_args_sereal_decoder(pTHX_ OP *entersubop, GV *namegv, SV *ckobj)
     pushop->op_sibling = cvop;
     lastargop->op_sibling = NULL;
     op_free(entersubop);
-    newop = newUNOP(OP_CUSTOM, 0, firstargop);
+    newop = newUNOP(OP_NULL, 0, firstargop);
+    newop->op_type    = OP_CUSTOM;
     newop->op_private = opopt;
     newop->op_ppaddr = opopt & OPOPT_LOOKS_LIKE ? THX_pp_looks_like_sereal : THX_pp_sereal_decode;
     return newop;

--- a/Perl/Encoder/Encoder.xs
+++ b/Perl/Encoder/Encoder.xs
@@ -112,7 +112,8 @@ THX_ck_entersub_args_sereal_encode_with_object(pTHX_ OP *entersubop, GV *namegv,
   pushop->op_sibling = cvop;
   lastargop->op_sibling = NULL;
   op_free(entersubop);
-  newop = newUNOP(OP_CUSTOM, 0, firstargop);
+  newop = newUNOP(OP_NULL, 0, firstargop);
+  newop->op_type    = OP_CUSTOM;
   newop->op_private = arity == 3;
   newop->op_ppaddr = THX_pp_sereal_encode_with_object;
 


### PR DESCRIPTION
This is arguably a bug in perl itself -- new.+OP() should let OP_CUSTOM pass -- but even if it were fixed in the core, something like this fix would still be needed to get the module working on older perls.

The alternative to this patch is unrolling newUNOP(), but that struck me as a losing battle.
