### PR TITLE
Coax EUMM into producing META 2.0 META.json

### DIFF
--- a/Perl/Decoder/Makefile.PL
+++ b/Perl/Decoder/Makefile.PL
@@ -58,21 +58,28 @@ WriteMakefile1(
     MIN_PERL_VERSION => '5.008',
     META_MERGE => {
         resources => {
-            repository => 'git://github.com/Sereal/Sereal.git',
-            bugtracker => 'https://github.com/Sereal/Sereal/issues',
+            repository => {
+              url => 'git://github.com/Sereal/Sereal.git',
+            },
+            bugtracker => {
+              web => 'https://github.com/Sereal/Sereal/issues',
+            },
         },
+        'meta-spec' => { version => 2 },
+    },
+    TEST_REQUIRES  => {
+        'Test::More' => 0.88,
+        'Scalar::Util' => 0,
+        'File::Spec' => 0,
+        'Test::LongString' => '0',
+        'Test::Warn' => '0',
+        'Data::Dumper' => '0',
     },
     BUILD_REQUIRES => {
         'XSLoader' => 0,
-        'Test::More' => 0.88,
         'File::Find' => 0,
-        'Scalar::Util' => 0,
-        'File::Spec' => 0,
         'File::Path' => 0,
         'ExtUtils::ParseXS' => '2.21',
-        'Test::LongString' => '0',
-        'Data::Dumper' => '0',
-        'Test::Warn' => '0',
     },
     NAME              => $module,
     VERSION_FROM      => 'lib/Sereal/Decoder.pm', # finds $VERSION
@@ -99,6 +106,10 @@ sub WriteMakefile1 {  #Written by Alexandr Ciornii, version 0.20. Added by eumm-
     $eumm_version=eval $eumm_version;
     die "EXTRA_META is deprecated" if exists $params{EXTRA_META};
     die "License not specified" if not exists $params{LICENSE};
+    if ($params{TEST_REQUIRES} and $eumm_version < 6.6303) {
+        $params{BUILD_REQUIRES}={ %{$params{BUILD_REQUIRES} || {}} , %{$params{TEST_REQUIRES}} };
+        delete $params{TEST_REQUIRES};
+    }
     if ($params{BUILD_REQUIRES} and $eumm_version < 6.5503) {
         #EUMM 6.5502 has problems with BUILD_REQUIRES
         $params{PREREQ_PM}={ %{$params{PREREQ_PM} || {}} , %{$params{BUILD_REQUIRES}} };

--- a/Perl/Encoder/Makefile.PL
+++ b/Perl/Encoder/Makefile.PL
@@ -70,22 +70,28 @@ WriteMakefile1(
     MIN_PERL_VERSION => '5.008',
     META_MERGE => {
         resources => {
-            repository => 'git://github.com/Sereal/Sereal.git',
-            bugtracker => 'https://github.com/Sereal/Sereal/issues',
+            repository => {
+              url => 'git://github.com/Sereal/Sereal.git',
+            },
+            bugtracker => {
+              web => 'https://github.com/Sereal/Sereal/issues',
+            },
         },
+        'meta-spec' => { version => 2 },
     },
-    BUILD_REQUIRES => {
+    TEST_REQUIRES => {
         'Test::More' => 0.88,
         'Scalar::Util' => 0,
-        'File::Find' => 0,
         'File::Spec' => 0,
-        'Scalar::Util' => 0,
+        'Test::LongString' => '0',
+        'Test::Warn' => '0',
+        'Data::Dumper' => '0',
+        'Sereal::Decoder' => '3.00',
+    },
+    BUILD_REQUIRES => {
+        'File::Find' => 0,
         'File::Path' => 0,
         'ExtUtils::ParseXS' => '2.21',
-        'Test::LongString' => '0',
-        'Data::Dumper' => '0',
-        'Test::Warn' => '0',
-        'Sereal::Decoder' => '3.00',
     },
     NAME              => $module,
     VERSION_FROM      => 'lib/Sereal/Encoder.pm', # finds $VERSION
@@ -112,6 +118,10 @@ sub WriteMakefile1 {  #Written by Alexandr Ciornii, version 0.20. Added by eumm-
     $eumm_version=eval $eumm_version;
     die "EXTRA_META is deprecated" if exists $params{EXTRA_META};
     die "License not specified" if not exists $params{LICENSE};
+    if ($params{TEST_REQUIRES} and $eumm_version < 6.6303) {
+        $params{BUILD_REQUIRES}={ %{$params{BUILD_REQUIRES} || {}} , %{$params{TEST_REQUIRES}} };
+        delete $params{TEST_REQUIRES};
+    }
     if ($params{BUILD_REQUIRES} and $eumm_version < 6.5503) {
         #EUMM 6.5502 has problems with BUILD_REQUIRES
         $params{PREREQ_PM}={ %{$params{PREREQ_PM} || {}} , %{$params{BUILD_REQUIRES}} };

--- a/Perl/Sereal/Makefile.PL
+++ b/Perl/Sereal/Makefile.PL
@@ -12,11 +12,16 @@ WriteMakefile1(
     MIN_PERL_VERSION => '5.008',
     META_MERGE => {
         resources => {
-            repository => 'git://github.com/Sereal/Sereal.git',
-            bugtracker => 'https://github.com/Sereal/Sereal/issues',
+            repository => {
+              url => 'git://github.com/Sereal/Sereal.git',
+            },
+            bugtracker => {
+              web => 'https://github.com/Sereal/Sereal/issues',
+            },
         },
+        'meta-spec' => { version => 2 },
     },
-    BUILD_REQUIRES => {
+    TEST_REQUIRES => {
         'Test::More' => 0.88,
         'Sereal::Encoder' => $VERSION,
         'Sereal::Decoder' => $VERSION,
@@ -38,6 +43,10 @@ sub WriteMakefile1 {  #Written by Alexandr Ciornii, version 0.20. Added by eumm-
     $eumm_version=eval $eumm_version;
     die "EXTRA_META is deprecated" if exists $params{EXTRA_META};
     die "License not specified" if not exists $params{LICENSE};
+    if ($params{TEST_REQUIRES} and $eumm_version < 6.6303) {
+        $params{BUILD_REQUIRES}={ %{$params{BUILD_REQUIRES} || {}} , %{$params{TEST_REQUIRES}} };
+        delete $params{TEST_REQUIRES};
+    }
     if ($params{BUILD_REQUIRES} and $eumm_version < 6.5503) {
         #EUMM 6.5502 has problems with BUILD_REQUIRES
         $params{PREREQ_PM}={ %{$params{PREREQ_PM} || {}} , %{$params{BUILD_REQUIRES}} };


### PR DESCRIPTION
As per #59.

The good folks in #toolchain knew a trick that would make it work.

However, its a tentative pull req, because I don't know what all the right deps are for different phases.

It appears to do the right thing, however:
- It required writing the resources entry in META 2.0 Format: https://metacpan.org/pod/CPAN::Meta::Spec#resources
- I moved only deps I could find in t/ to `TEST_REQUIRES`
- There's a bunch of deps that are declared, but I can't see them used anywhere by a source grep, and so I left them in place.
- I'm not entirely sure why `Sereal` declares `Sereal::Encode`  and `::Decode` as both `BUILD_` and `PREREQ_PM`, it might have just been a phasing thing or and accident or ????

=~ I totally anticipate that this pull request won't be merged as-is, but I'll adjust it as needs require if you want, or if you wish to steal parts from it and not merge it, that's cool too =)
