### PR TITLE
Fix freeze writing from go.

### DIFF
--- a/Go/sereal/encode.go
+++ b/Go/sereal/encode.go
@@ -419,6 +419,9 @@ func (e *Encoder) encodeViaReflection(b []byte, rv reflect.Value, isKeyOrClass b
 
 			b = append(b, typeOBJECT_FREEZE)
 			b = e.encodeString(b, concreteName(rv), true, strTable)
+			b = append(b, typeREFN)
+			b = append(b, typeARRAY)
+			b = varint(b, uint(1))
 			return e.encode(b, reflect.ValueOf(by), false, false, strTable, ptrTable)
 		}
 	}


### PR DESCRIPTION
I may be completely off base here, but:

The spec (and the perl decoder) expect frozen objects
to be wrapped in an arrayref.

My use case was a time.Time frozen with PerlCompat = true,
and revived into perl using Sereal::Decode.

With this fix in place I can correctly transfer a time.Time into perl and THAW it into Time::Piece or Decode. (Though time.Time's MarshalBinary is a bit of a bear trap)

This breaks the decoder tests, so it's really just a start of a discussion what needs changing,
or perhaps just explaining that I was missing something in the first place.