### PR TITLE
Tests and fix for FREEZE/THAW roundtripping

### DIFF
--- a/Go/sereal/Makefile
+++ b/Go/sereal/Makefile
@@ -8,8 +8,11 @@ test: test_dir
 
 compat: test_dir
 	-rm -f test_dir/test_data_*-go.out
-	-go test -test.run=TestCorpus
+	-rm -f test_freeze/*-go.out
+	go test -test.run=TestCorpus
+	go test -test.run=TestPrepareFreezeRoundtrip
 	prove ./test-compat.pl
+	env RUN_FREEZE=1 go test -test.run=TestFreezeRoundtrip
 
 ../../Perl/Decoder/blib:
 	cd ../../Perl/Decoder/ ; perl Makefile.PL
@@ -26,6 +29,7 @@ test_dir: ../../Perl/Decoder/blib ../../Perl/Encoder/blib test_dir/VERSION_$(COR
 
 test_files:
 	mkdir -p test_dir
+	mkdir -p test_freeze
 	perl -Mblib=../../Perl/Encoder/blib -MSereal::Encoder cmd/gen/test-decode-struct.pl test_dir
 
 test_dir/VERSION_$(CORPUS_PROTO_VER):

--- a/Go/sereal/encode.go
+++ b/Go/sereal/encode.go
@@ -410,7 +410,7 @@ func (e *Encoder) encodeStrMap(by []byte, m map[string]interface{}, isRefNext bo
  * Encode via reflection
  *************************************/
 func (e *Encoder) encodeViaReflection(b []byte, rv reflect.Value, isKeyOrClass bool, isRefNext bool, strTable map[string]int, ptrTable map[uintptr]int) ([]byte, error) {
-	if !e.DisableFREEZE && rv.Kind() != reflect.Invalid {
+	if !e.DisableFREEZE && rv.Kind() != reflect.Invalid && rv.Kind() != reflect.Ptr {
 		if m, ok := rv.Interface().(encoding.BinaryMarshaler); ok {
 			by, err := m.MarshalBinary()
 			if err != nil {


### PR DESCRIPTION
The first change fixes a bug by skipping over the FREEZE behavior for all pointer types that implement the MarshalBinary interface.

This prevents jumping the gun on calling the interface when it's not yet the type that actually implements it, but rather a pointer to it that gets the interface indirectly, which would serialize the data from the referant with class tag set as the concreteName of the reference.

This is a dubious fix, since it prevents legitimate pointer based implementations of the MarsahalBinary interface from being used, but arguably this condition could be relaxed later when semantics will be figured out. I also expect this code to be redone if a Sereal specific marshaling interface is defined.