### PR TITLE
Tests and bug fixes for nil pointers in structs

### DIFF
--- a/Go/sereal/decode.go
+++ b/Go/sereal/decode.go
@@ -930,6 +930,13 @@ func (d *Decoder) decodeHashViaReflection(by []byte, idx int, ln int, ptr reflec
 			}
 		}
 
+	case reflect.Ptr:
+		if ptr.IsNil() {
+			n := reflect.New(ptr.Type().Elem())
+			ptr.Set(n)
+		}
+
+		return d.decodeHashViaReflection(by, idx, ln, ptr.Elem())
 	case reflect.Struct:
 		tags := d.tcache.Get(ptr)
 		var err error

--- a/Go/sereal/encode.go
+++ b/Go/sereal/encode.go
@@ -571,7 +571,9 @@ func (e *Encoder) encodePointer(by []byte, rv reflect.Value, strTable map[string
 
 		by = append(by, typeREFN)
 
-		ptrTable[rvptr] = lenbOrig
+		if rvptr != 0 {
+			ptrTable[rvptr] = lenbOrig
+		}
 
 		var err error
 		by, err = e.encode(by, rv.Elem(), false, true, strTable, ptrTable)


### PR DESCRIPTION
Sereal encoding encodes nil pointers of different types as being the same type, causing decoding to error on Set() being the wrong type

Sereal decoding explodes on unpacking of pointers to structs, this adds a case for handling of Ptr kinds in decodeHashViaReflection()