### PR TITLE
perl: only include the -Werror= ccflags when the compiler supports them

### DIFF
--- a/Perl/Decoder/Makefile.PL
+++ b/Perl/Decoder/Makefile.PL
@@ -17,7 +17,7 @@ require inc::Sereal::BuildTools;
 inc::Sereal::BuildTools::link_files($shared_dir) if $in_source_repo;
 inc::Sereal::BuildTools::generate_constant_includes($module) if $in_source_repo;
 
-our $OPTIMIZE;
+my $optimize = inc::Sereal::BuildTools::build_optimize();
 
 # TODO Configure/optimize for miniz:
 #   * Important: For best perf. be sure to customize the below macros for your target platform:
@@ -28,40 +28,7 @@ our $OPTIMIZE;
 my $libs = '';
 my $objects = '$(BASEEXT)$(OBJ_EXT) srl_decoder$(OBJ_EXT)';
 my $defines = join " ", map "-D$_", grep exists $ENV{$_}, qw(NOINLINE DEBUG MEMDEBUG NDEBUG);
-
-my $clang = 0;
-if ($Config{gccversion}) {
-    $OPTIMIZE = '-O3';
-    if ($Config{gccversion} =~ /[Cc]lang/) { # clang.
-        $clang = 1;
-    }
-
-    my $gccversion = 0;
-    if ( $Config{gccversion} =~ /^(\d+\.\d+)/ ) {
-        $gccversion = $1;
-    }
-
-    if ( $clang || $gccversion >= 4.3 ) {
-        # -Werror= introduced in GCC 4.3
-        # For trapping C++ // comments we would need -std=c89 (aka -ansi)
-        # but that may be asking too much of different platforms.
-        $OPTIMIZE .= ' -Werror=declaration-after-statement ';
-    }
-} elsif ($Config{osname} eq 'MSWin32') {
-    $OPTIMIZE = '-O2 -W4';
-} else {
-    $OPTIMIZE = $Config{optimize};
-}
-
-if ($ENV{DEBUG}) {
-  $OPTIMIZE .= ' -g';
-  if ($ENV{DEBUG} > 0 && $Config{gccversion}) {
-      $OPTIMIZE .= ' -Wextra' if $ENV{DEBUG} > 1;
-      $OPTIMIZE .= ' -pedantic' if $ENV{DEBUG} > 5; # not pretty
-      $OPTIMIZE .= ' -Weverything' if ($ENV{DEBUG} > 6 && $clang); # really not pretty
-  }
-}
-else {
+if (!$ENV{DEBUG}) {
   $defines .= " -DNDEBUG";
 }
 
@@ -122,13 +89,13 @@ WriteMakefile1(
     LIBS              => [$libs], # e.g., '-lm'
     DEFINE            => $defines,
     INC               => '-I.', # e.g., '-I. -I/usr/include/other'
-    OPTIMIZE          => $OPTIMIZE,
+    OPTIMIZE          => $optimize,
     OBJECT            => $objects,
     test              => {
         TESTS => "t/*.t t/*/*/*.t"
     },
 );
-$ENV{OPTIMIZE} = $OPTIMIZE;
+$ENV{OPTIMIZE} = $optimize;
 
 sub WriteMakefile1 {
     #Original by Alexandr Ciornii, modified by Yves Orton

--- a/Perl/Decoder/Makefile.PL
+++ b/Perl/Decoder/Makefile.PL
@@ -29,28 +29,28 @@ my $libs = '';
 my $objects = '$(BASEEXT)$(OBJ_EXT) srl_decoder$(OBJ_EXT)';
 my $defines = join " ", map "-D$_", grep exists $ENV{$_}, qw(NOINLINE DEBUG MEMDEBUG NDEBUG);
 
-my $moderngccish = 0;
 my $clang = 0;
 if ($Config{gccversion}) {
     $OPTIMIZE = '-O3';
     if ($Config{gccversion} =~ /[Cc]lang/) { # clang.
         $clang = 1;
-        $moderngccish = 1;
-    } elsif ($Config{gccversion} =~ /^[123]\./) { # Ancient gcc.
-        $moderngccish = 0;
-    } else { # Modern gcc.
-        $moderngccish = 1;
+    }
+
+    my $gccversion = 0;
+    if ( $Config{gccversion} =~ /^(\d+\.\d+)/ ) {
+        $gccversion = $1;
+    }
+
+    if ( $clang || $gccversion >= 4.3 ) {
+        # -Werror= introduced in GCC 4.3
+        # For trapping C++ // comments we would need -std=c89 (aka -ansi)
+        # but that may be asking too much of different platforms.
+        $OPTIMIZE .= ' -Werror=declaration-after-statement ';
     }
 } elsif ($Config{osname} eq 'MSWin32') {
     $OPTIMIZE = '-O2 -W4';
 } else {
     $OPTIMIZE = $Config{optimize};
-}
-
-# For trapping C++ // comments we would need -std=c89 (aka -ansi)
-# but that may be asking too much of different platforms.
-if ($moderngccish) {
-    $OPTIMIZE .= ' -Werror=declaration-after-statement';
 }
 
 if ($ENV{DEBUG}) {

--- a/Perl/Encoder/Makefile.PL
+++ b/Perl/Encoder/Makefile.PL
@@ -30,28 +30,28 @@ my $objects = '$(BASEEXT)$(OBJ_EXT) srl_encoder$(OBJ_EXT)';
 my $defines = join " ", map "-D$_", grep exists $ENV{$_},
               qw(NOINLINE DEBUG MEMDEBUG NDEBUG ENABLE_DANGEROUS_HACKS);
 
-my $moderngccish = 0;
 my $clang = 0;
 if ($Config{gccversion}) {
     $OPTIMIZE = '-O3';
     if ($Config{gccversion} =~ /[Cc]lang/) { # clang.
         $clang = 1;
-        $moderngccish = 1;
-    } elsif ($Config{gccversion} =~ /^[123]\./) { # Ancient gcc.
-        $moderngccish = 0;
-    } else { # Modern gcc.
-        $moderngccish = 1;
+    }
+
+    my $gccversion = 0;
+    if ( $Config{gccversion} =~ /^(\d+\.\d+)/ ) {
+        $gccversion = $1;
+    }
+
+    if ( $clang || $gccversion >= 4.3 ) {
+        # -Werror= introduced in GCC 4.3
+        # For trapping C++ // comments we would need -std=c89 (aka -ansi)
+        # but that may be asking too much of different platforms.
+        $OPTIMIZE .= ' -Werror=declaration-after-statement ';
     }
 } elsif ($Config{osname} eq 'MSWin32') {
     $OPTIMIZE = '-O2 -W4';
 } else {
     $OPTIMIZE = $Config{optimize};
-}
-
-# For trapping C++ // comments we would need -std=c89 (aka -ansi)
-# but that may be asking too much of different platforms.
-if ($moderngccish) {
-    $OPTIMIZE .= ' -Werror=declaration-after-statement ';
 }
 
 if ($ENV{DEBUG}) {

--- a/Perl/Encoder/Makefile.PL
+++ b/Perl/Encoder/Makefile.PL
@@ -23,46 +23,14 @@ inc::Sereal::BuildTools::generate_constant_includes($module) if $in_source_repo;
 #     #define MINIZ_LITTLE_ENDIAN 1
 #     #define MINIZ_HAS_64BIT_REGISTERS 1
 
-our $OPTIMIZE;
+my $optimize = inc::Sereal::BuildTools::build_optimize();
 
 my $libs = '';
 my $objects = '$(BASEEXT)$(OBJ_EXT) srl_encoder$(OBJ_EXT)';
 my $defines = join " ", map "-D$_", grep exists $ENV{$_},
               qw(NOINLINE DEBUG MEMDEBUG NDEBUG ENABLE_DANGEROUS_HACKS);
 
-my $clang = 0;
-if ($Config{gccversion}) {
-    $OPTIMIZE = '-O3';
-    if ($Config{gccversion} =~ /[Cc]lang/) { # clang.
-        $clang = 1;
-    }
-
-    my $gccversion = 0;
-    if ( $Config{gccversion} =~ /^(\d+\.\d+)/ ) {
-        $gccversion = $1;
-    }
-
-    if ( $clang || $gccversion >= 4.3 ) {
-        # -Werror= introduced in GCC 4.3
-        # For trapping C++ // comments we would need -std=c89 (aka -ansi)
-        # but that may be asking too much of different platforms.
-        $OPTIMIZE .= ' -Werror=declaration-after-statement ';
-    }
-} elsif ($Config{osname} eq 'MSWin32') {
-    $OPTIMIZE = '-O2 -W4';
-} else {
-    $OPTIMIZE = $Config{optimize};
-}
-
-if ($ENV{DEBUG}) {
-  $OPTIMIZE .= ' -g';
-  if ($ENV{DEBUG} > 0 && $Config{gccversion}) {
-      $OPTIMIZE .= ' -Wextra' if $ENV{DEBUG} > 1;
-      $OPTIMIZE .= ' -pedantic' if $ENV{DEBUG} > 5; # not pretty
-      $OPTIMIZE .= ' -Weverything' if ($ENV{DEBUG} > 6 && $clang); # really not pretty
-  }
-}
-else {
+if (!$ENV{DEBUG} ) {
   $defines .= " -DNDEBUG";
 }
 
@@ -133,13 +101,13 @@ WriteMakefile1(
     LIBS              => [$libs], # e.g., '-lm'
     DEFINE            => $defines,
     INC               => '-I.', # e.g., '-I. -I/usr/include/other'
-    OPTIMIZE          => $OPTIMIZE,
+    OPTIMIZE          => $optimize,
     OBJECT            => $objects,
     test              => {
         TESTS => "t/*.t t/*/*/*.t",
     },
 );
-$ENV{OPTIMIZE} = $OPTIMIZE;
+$ENV{OPTIMIZE} = $optimize;
 
 sub WriteMakefile1 {
     #Original by Alexandr Ciornii, modified by Yves Orton

--- a/Perl/Merger/Makefile.PL
+++ b/Perl/Merger/Makefile.PL
@@ -23,46 +23,14 @@ inc::Sereal::BuildTools::generate_constant_includes($module) if $in_source_repo;
 #     #define MINIZ_LITTLE_ENDIAN 1
 #     #define MINIZ_HAS_64BIT_REGISTERS 1
 
-our $OPTIMIZE;
+my $optimize = inc::Sereal::BuildTools::build_optimize();
 
 my $libs = '';
 my $objects = '$(BASEEXT)$(OBJ_EXT) srl_merger$(OBJ_EXT)';
 my $defines = join " ", map "-D$_", grep exists $ENV{$_},
               qw(NOINLINE DEBUG MEMDEBUG NDEBUG ENABLE_DANGEROUS_HACKS);
 
-my $clang = 0;
-if ($Config{gccversion}) {
-    $OPTIMIZE = '-O3';
-    if ($Config{gccversion} =~ /[Cc]lang/) { # clang.
-        $clang = 1;
-    }
-
-    my $gccversion = 0;
-    if ( $Config{gccversion} =~ /^(\d+\.\d+)/ ) {
-        $gccversion = $1;
-    }
-
-    if ( $clang || $gccversion >= 4.3 ) {
-        # -Werror= introduced in GCC 4.3
-        # For trapping C++ // comments we would need -std=c89 (aka -ansi)
-        # but that may be asking too much of different platforms.
-        $OPTIMIZE .= ' -Werror=declaration-after-statement ';
-    }
-} elsif ($Config{osname} eq 'MSWin32') {
-    $OPTIMIZE = '-O2 -W4';
-} else {
-    $OPTIMIZE = $Config{optimize};
-}
-
-if ($ENV{DEBUG}) {
-  $OPTIMIZE .= ' -g';
-  if ($ENV{DEBUG} > 0 && $Config{gccversion}) {
-      $OPTIMIZE .= ' -Wextra' if $ENV{DEBUG} > 1;
-      $OPTIMIZE .= ' -pedantic' if $ENV{DEBUG} > 5; # not pretty
-      $OPTIMIZE .= ' -Weverything' if ($ENV{DEBUG} > 6 && $clang); # really not pretty
-  }
-}
-else {
+if (!$ENV{DEBUG}) {
   $defines .= " -DNDEBUG";
 }
 
@@ -124,10 +92,10 @@ WriteMakefile1(
     LIBS              => [$libs], # e.g., '-lm'
     DEFINE            => $defines,
     INC               => '-I.', # e.g., '-I. -I/usr/include/other'
-    OPTIMIZE          => $OPTIMIZE,
+    OPTIMIZE          => $optimize,
     OBJECT            => $objects,
 );
-$ENV{OPTIMIZE} = $OPTIMIZE;
+$ENV{OPTIMIZE} = $optimize;
 
 sub WriteMakefile1 {
     #Original by Alexandr Ciornii, modified by Yves Orton

--- a/Perl/Merger/Makefile.PL
+++ b/Perl/Merger/Makefile.PL
@@ -30,28 +30,28 @@ my $objects = '$(BASEEXT)$(OBJ_EXT) srl_merger$(OBJ_EXT)';
 my $defines = join " ", map "-D$_", grep exists $ENV{$_},
               qw(NOINLINE DEBUG MEMDEBUG NDEBUG ENABLE_DANGEROUS_HACKS);
 
-my $moderngccish = 0;
 my $clang = 0;
 if ($Config{gccversion}) {
     $OPTIMIZE = '-O3';
     if ($Config{gccversion} =~ /[Cc]lang/) { # clang.
         $clang = 1;
-        $moderngccish = 1;
-    } elsif ($Config{gccversion} =~ /^[123]\./) { # Ancient gcc.
-        $moderngccish = 0;
-    } else { # Modern gcc.
-        $moderngccish = 1;
+    }
+
+    my $gccversion = 0;
+    if ( $Config{gccversion} =~ /^(\d+\.\d+)/ ) {
+        $gccversion = $1;
+    }
+
+    if ( $clang || $gccversion >= 4.3 ) {
+        # -Werror= introduced in GCC 4.3
+        # For trapping C++ // comments we would need -std=c89 (aka -ansi)
+        # but that may be asking too much of different platforms.
+        $OPTIMIZE .= ' -Werror=declaration-after-statement ';
     }
 } elsif ($Config{osname} eq 'MSWin32') {
     $OPTIMIZE = '-O2 -W4';
 } else {
     $OPTIMIZE = $Config{optimize};
-}
-
-# For trapping C++ // comments we would need -std=c89 (aka -ansi)
-# but that may be asking too much of different platforms.
-if ($moderngccish) {
-    $OPTIMIZE .= ' -Werror=declaration-after-statement ';
 }
 
 if ($ENV{DEBUG}) {

--- a/Perl/Path/Iterator/Makefile.PL
+++ b/Perl/Path/Iterator/Makefile.PL
@@ -63,6 +63,6 @@ inc::Sereal::BuildTools::WriteMakefile(
     LIBS              => [$libs], # e.g., '-lm'
     DEFINE            => $defines,
     INC               => '-I..', # e.g., '-I. -I/usr/include/other'
-    OPTIMIZE          => inc::Sereal::BuildTools::build_optimize(),
+    OPTIMIZE          => inc::Sereal::BuildTools::build_optimize({ std => 'gnu89' }),
     OBJECT            => $objects,
 );

--- a/Perl/Path/Makefile.PL
+++ b/Perl/Path/Makefile.PL
@@ -59,7 +59,7 @@ inc::Sereal::BuildTools::WriteMakefile(
     LIBS              => [$libs], # e.g., '-lm'
     DEFINE            => $defines,
     INC               => '-I.', # e.g., '-I. -I/usr/include/other'
-    OPTIMIZE          => inc::Sereal::BuildTools::build_optimize(),
+    OPTIMIZE          => inc::Sereal::BuildTools::build_optimize({ std => 'gnu89' }),
     OBJECT            => $objects,
     test              => { TESTS => "t/*.t t/*/*/*.t" },
     DIR               => [ 'Iterator', 'Tie' ],

--- a/Perl/Path/Tie/Makefile.PL
+++ b/Perl/Path/Tie/Makefile.PL
@@ -57,6 +57,6 @@ inc::Sereal::BuildTools::WriteMakefile(
     LIBS              => [$libs], # e.g., '-lm'
     DEFINE            => $defines,
     INC               => '-I..', # e.g., '-I. -I/usr/include/other'
-    OPTIMIZE          => inc::Sereal::BuildTools::build_optimize(),
+    OPTIMIZE          => inc::Sereal::BuildTools::build_optimize({ std => 'gnu89' }),
     OBJECT            => $objects,
 );

--- a/Perl/Splitter/Makefile.PL
+++ b/Perl/Splitter/Makefile.PL
@@ -18,7 +18,7 @@ my $module = "Sereal::Splitter";
  inc::Sereal::BuildTools::generate_constant_includes($module) if $in_source_repo;
 
 `rm -rf t/004_testset.t t/700_roundtrip t/data t/lib`;
-my $optimize = inc::Sereal::BuildTools::build_optimize();
+my $optimize = inc::Sereal::BuildTools::build_optimize({ catch_violations => 0 });
 
 # TODO Configure/optimize for miniz:
 #   * Important: For best perf. be sure to customize the below macros for your target platform:

--- a/Perl/Splitter/Makefile.PL
+++ b/Perl/Splitter/Makefile.PL
@@ -18,7 +18,7 @@ my $module = "Sereal::Splitter";
  inc::Sereal::BuildTools::generate_constant_includes($module) if $in_source_repo;
 
 `rm -rf t/004_testset.t t/700_roundtrip t/data t/lib`;
-our $OPTIMIZE;
+my $optimize = inc::Sereal::BuildTools::build_optimize();
 
 # TODO Configure/optimize for miniz:
 #   * Important: For best perf. be sure to customize the below macros for your target platform:
@@ -27,18 +27,7 @@ our $OPTIMIZE;
 #     #define MINIZ_HAS_64BIT_REGISTERS 1
 
 my $defines = join " ", map "-D$_", grep exists $ENV{$_}, qw(NOINLINE DEBUG MEMDEBUG NDEBUG);
-if ($Config{gccversion}) {
-    $OPTIMIZE = '-O3 -Wall -W';
-} elsif ($Config{osname} eq 'MSWin32') {
-    $OPTIMIZE = '-O2 -W4';
-} else {
-    $OPTIMIZE = $Config{optimize};
-}
-
-if ($ENV{DEBUG}) {
-  $OPTIMIZE .= ' -g';
-}
-else {
+if (!$ENV{DEBUG}) {
   $defines .= " -DNDEBUG";
 }
 
@@ -87,13 +76,13 @@ WriteMakefile1(
     LIBS              => [''], # e.g., '-lm'
     DEFINE            => $defines,
     INC               => '-I.', # e.g., '-I. -I/usr/include/other'
-    OPTIMIZE          => $OPTIMIZE,
+    OPTIMIZE          => $optimize,
     OBJECT            => '$(O_FILES)',
     test              => {
         TESTS => "t/*.t t/*/*/*.t"
     },
 );
-$ENV{OPTIMIZE} = $OPTIMIZE;
+$ENV{OPTIMIZE} = $optimize;
 
 sub WriteMakefile1 {  #Written by Alexandr Ciornii, version 0.20. Added by eumm-upgrade.
     my %params=@_;

--- a/Perl/shared/inc/Sereal/BuildTools.pm
+++ b/Perl/shared/inc/Sereal/BuildTools.pm
@@ -103,7 +103,10 @@ sub build_defines {
 }
 
 sub build_optimize {
-    my $opts = shift || {};
+    my $cc_flags = shift || {};
+
+    my $std_mode = $cc_flags->{std};
+    my $catch_violations = exists $cc_flags->{catch_violations} ? $cc_flags->{catch_violations} : 1;
 
     my $OPTIMIZE;
 
@@ -119,20 +122,21 @@ sub build_optimize {
             $gccversion = $1;
         }
 
-        if ( $clang || $gccversion >= 4.3 ) {
+        if ( $catch_violations && ($clang || $gccversion >= 4.3) ) {
             # -Werror= introduced in GCC 4.3
             # For trapping C++ // comments we would need -std=c89 (aka -ansi)
             # but that may be asking too much of different platforms.
             $OPTIMIZE .= ' -Werror=declaration-after-statement ';
         }
 
-        if ( $clang && $opts->{std} ) {
-            $OPTIMIZE .= " -std=$opts->{std}"; # http://clang.llvm.org/compatibility.html
-        }
     } elsif ($Config{osname} eq 'MSWin32') {
         $OPTIMIZE = '-O2 -W4';
     } else {
         $OPTIMIZE = $Config{optimize};
+    }
+
+    if ( $clang && $std_mode ) {
+        $OPTIMIZE .= " -std=$std_mode"; # http://clang.llvm.org/compatibility.html
     }
 
     if ($ENV{DEBUG}) {


### PR DESCRIPTION
Hi,

Running `make` using gcc 4.1.2 + perl (5.8.8) + Sereal master fails because gcc 4.1.2 does not support making warnings into errors:

```
cc1: error: unrecognized command line option "-Werror=declaration-after-statement"
```

[gcc 4.3.0](https://gcc.gnu.org/onlinedocs/gcc-4.3.0/gcc/Warning-Options.html#Warning-Options) is the first version that I can find that mentions -Werror=

This doesn't affect CPAN because the flag was introduced after the latest release in be69589221ba5f79e5cc53cf220727ebe5d35c22.

This pull request is tested against gcc 4.7.2 and 4.1.2 20080704 (Red Hat 4.1.2-48) and seems to work.

It appears to duplicate `inc::Sereal::BuildTools::build_optimize` so I could update the Makefile.PLs to call that instead. Could also move this ccflag so it is only enabled when either `$ENV{DEBUG}` or `$in_source_repo` are set. I'm happy to rework this pull request
