### PR TITLE
use hardlinks on Win32 instead of symlinks to make repo buildable

### DIFF
--- a/Perl/shared/inc/Sereal/BuildTools.pm
+++ b/Perl/shared/inc/Sereal/BuildTools.pm
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 
 use Config;
+use constant OSNAME => $^O;
 
 sub link_files {
   my $shared_dir = shift;
@@ -36,7 +37,14 @@ sub link_files {
             my $ref = join "/", ("..") x scalar(@d);
             my $subd = join "/", @d;
             chdir $subd if length($ref);
-            symlink(join("/", grep length, $ref, $shared_dir, $subd, $fname), $fname);
+            my $srcfname = join("/", grep length, $ref, $shared_dir, $subd, $fname);
+            if (OSNAME eq 'MSWin32') {
+              die "link($srcfname, $fname) failed: $!"
+                unless link($srcfname, $fname); #only NTFS implements it
+            }
+            else {
+              symlink($srcfname, $fname);
+            }
             chdir($ref) if length($ref);
           }
         },


### PR DESCRIPTION
Previously the git repo couldn't be built on Win32 because symlink throws
an exception that is it unimplemented on Win32 perl. Hard links are
implemented on Win32, and usually available since nearly all modern Win32
OS installs use NTFS (if you keep Sereal git repo on a USB stick this will
fail). Use a constant for constant folding since the sub is called in a
loop.