### PR TITLE
Fixes for Solaris and AIX compilers

### DIFF
--- a/Perl/shared/snappy/csnappy.h
+++ b/Perl/shared/snappy/csnappy.h
@@ -16,7 +16,12 @@ extern "C" {
 #ifndef __GNUC__
 #define __attribute__(x) /*NOTHING*/
 #endif
-#include <stdint.h>
+
+#if defined(__SUNPRO_C) || defined(_AIX)
+# include <inttypes.h>
+#else
+# include <stdint.h>
+#endif
 
 /*
  * Returns the maximal size of the compressed representation of

--- a/Perl/shared/snappy/csnappy_internal_userspace.h
+++ b/Perl/shared/snappy/csnappy_internal_userspace.h
@@ -123,6 +123,13 @@ Albert Lee
 #define __LITTLE_ENDIAN	1234
 #define __BYTE_ORDER	LITTLE_ENDIAN
 
+#elif defined(_AIX)
+
+#include <sys/machine.h>
+#define __LITTLE_ENDIAN LITTLE_ENDIAN
+#define __BIG_ENDIAN BIG_ENDIAN
+#define __BYTE_ORDER __BIG_ENDIAN
+
 #elif defined(__APPLE__)
 
 #include <machine/endian.h>

--- a/Perl/shared/snappy/csnappy_internal_userspace.h
+++ b/Perl/shared/snappy/csnappy_internal_userspace.h
@@ -71,7 +71,13 @@ typedef __int32 int32_t; /* Sereal specific change, see csnappy_decompress.c(271
 #endif
 
 #else
-#include <stdint.h>
+
+#if defined(__SUNPRO_C) || defined(_AIX)
+# include <inttypes.h>
+#else
+# include <stdint.h>
+#endif
+
 #endif
 
 #ifdef _GNU_SOURCE


### PR DESCRIPTION
1. Both the Solaris and AIX vendor compilers don't provide stdint.h, but have inttypes.h that works just as well. There's probably a better way to do this without duplication, but since the header structure is a bit complex and probably different for each language, I just put the same block in both headers.

2. AIX also needed an endian define section.

Tested with the Perl modules only, using rather old OS versions: Solaris 9 (SPARC and x86) and AIX 5.3.