### PR TITLE
make SRL_ZSTD constant exportable from Sereal::Encoder module.

### DIFF
--- a/Perl/Encoder/lib/Sereal/Encoder.pm
+++ b/Perl/Encoder/lib/Sereal/Encoder.pm
@@ -79,6 +79,7 @@ our @EXPORT_OK = qw(
   SRL_UNCOMPRESSED
   SRL_SNAPPY
   SRL_ZLIB
+  SRL_ZSTD
 );
 our %EXPORT_TAGS = (all => \@EXPORT_OK);
 # export by default if run from command line


### PR DESCRIPTION
The documentation of Sereal::Encoder module[1] suggest that
Sereal::Encoder can export SRL_ZSTD constant but that has
not been the case.

This commit put that constant inside the @EXPORT_OK list,
just like other constants for the `compress` parameter.

[1]: https://github.com/Sereal/Sereal/blob/master/Perl/Encoder/lib/Sereal/Encoder.pm#L171