### PR TITLE
Python: add support for varint and undef

### DIFF
--- a/Python/sereal/constants.py
+++ b/Python/sereal/constants.py
@@ -6,7 +6,9 @@ SRL_SHORT_BINARY_LEN                = 31
 
 SRL_TYPE_POS_0                      = 0
 SRL_NEG_16                          = 16
+SRL_TYPE_VARINT                     = 32
 SRL_TYPE_FLOAT                      = 34
+SRL_TYPE_UNDEF                      = 37
 SRL_TYPE_BINARY                     = 38
 SRL_TYPE_REFN                       = 40
 SRL_TYPE_REFP                       = 41

--- a/Python/sereal/decoder.py
+++ b/Python/sereal/decoder.py
@@ -65,6 +65,12 @@ class SrlDecoder(object):
         elif tag == const.SRL_TYPE_FLOAT:
             return self.reader.read_float()
 
+        elif tag == const.SRL_TYPE_VARINT:
+            return self.reader.read_varint()
+
+        elif tag == const.SRL_TYPE_UNDEF:
+            return None
+
         elif (tag == const.SRL_TYPE_BINARY):
             return self._decode_binary(tag)
 


### PR DESCRIPTION
These two are missing and trivial to implement.