### PR TITLE
py: Fix auto decoding BINARY tags as UTF-8

### DIFF
--- a/Python/README.md
+++ b/Python/README.md
@@ -17,6 +17,6 @@ Basic implementation of the Sereal protocol in Python.
 
 ### Miscellaneous
 
-- Python 3.5, 2.7
+- Python 3.5+
 - No Python encoder
 - Not Perl compatible

--- a/Python/sereal/reader.py
+++ b/Python/sereal/reader.py
@@ -60,7 +60,12 @@ class SrlDocumentReader(object):
         fmt = '<d'
         return self._read_unpack(fmt)
 
-    def read_str(self, slen):
+    def read_str(self, slen, str_encoding='utf-8'):
         fmt = '{0}s'.format(slen)
         val = self._read_unpack(fmt)
-        return bytes.decode(val, encoding='utf-8')
+        return bytes.decode(val, encoding=str_encoding)
+
+    def read_bin(self, slen):
+        fmt = '{0}s'.format(slen)
+        val = self._read_unpack(fmt)
+        return val


### PR DESCRIPTION
According the the Sereal spec BINARY and SHORT BINARY tags should be read
verbatim. In the first release of the Python decoder BINARY tags were
treated as STR_UTF8. This commit fixes this behaviour to comply with the
decoding spec. See the README details for changing the decoder behaviour.

WARNING: This is a breaking commit for Python 2 users as Python 2
will no longer be supported. See Python 2 deprecation for more details.