### PR TITLE
Fix POD Errors & Warnings

### DIFF
--- a/Perl/Decoder/lib/Sereal/Performance.pm
+++ b/Perl/Decoder/lib/Sereal/Performance.pm
@@ -19,16 +19,16 @@ Sereal::Performance - Getting the most out of the Perl-Sereal implementation
   # Usually, Sereal is a lot faster than most of one's code,
   # so unless you are doing bulk encoding/decoding, you are
   # better off optimizing for maintainability.
-  
+
   use Sereal qw(sereal_encode_with_object
                 sereal_decode_with_object);
   my $enc = Sereal::Encoder->new();
   my $dec = Sereal::Decoder->new();
-  
+
   my $big_data_structure = {...};
-  
+
   my $srldoc = sereal_encode_with_object($enc, $big_data_structure);
-  
+
   my $and_back = sereal_decode_with_object($dec, $srldoc);
 
 =head1 DESCRIPTION

--- a/Perl/Path/lib/Sereal/Path.pm
+++ b/Perl/Path/lib/Sereal/Path.pm
@@ -79,10 +79,10 @@ please use appropriate link above.
 
   use Sereal::Path;
   use Sereal::Encoder qw/encode_sereal/;
-  
+
   my $data = [ { foo => 'bar' }, { foo => 'barbar' } ];
   my $sp = Sereal::Path->new(encode_sereal($data));
-  
+
   # $result will contain { foo => 'bar' }
   my $result = $sp->traverse('$[0]');
 

--- a/Perl/shared/inc/Devel/CheckLib.pm
+++ b/Perl/shared/inc/Devel/CheckLib.pm
@@ -37,7 +37,7 @@ library and its headers are available.
 
     check_lib_or_exit( lib => 'jpeg', header => 'jpeglib.h' );
     check_lib_or_exit( lib => [ 'iconv', 'jpeg' ] );
-  
+
     # or prompt for path to library and then do this:
     check_lib_or_exit( lib => 'jpeg', libpath => $additional_path );
 

--- a/sereal_spec.pod
+++ b/sereal_spec.pod
@@ -86,7 +86,7 @@ Sereal protocol the document complies with.
 Up until now there have been versions 1, 2, 3 and 4 of the Sereal protocol.
 So the low four bits will be one of those values in little-endian.
 
-Currently only three types are defined:
+Currently only five types are defined:
 
 =over 4
 

--- a/sereal_spec.pod
+++ b/sereal_spec.pod
@@ -90,11 +90,11 @@ Currently only three types are defined:
 
 =over 4
 
-=item 0
+=item Z<>0
 
 Raw Sereal format. The data can be processed verbatim.
 
-=item 1
+=item Z<>1
 
 B<This is not a valid document type for Sereal protocol version 2 and up!>
 
@@ -103,7 +103,7 @@ In Sereal protocol version 1, this used to be
 It has long been advised to prefer I<2>, "incremental-decoding-enabled
 compressed Sereal," wherever possible.
 
-=item 2
+=item Z<>2
 
 Compressed Sereal format, using Google's Snappy compression internally as
 format I<1>, but supporting incremental-parsing. Long preferred over
@@ -117,7 +117,7 @@ where the varint signifies the length of the Snappy-compressed blob
 following it. See L</"NOTES ON IMPLEMENTATION"> below for a discussion on
 how to implement this efficiently.
 
-=item 3
+=item Z<>3
 
 Compressed Sereal format, using zlib compression. This does similar framing
 as the incremental Snappy compression (2):
@@ -131,7 +131,7 @@ how to implement this efficiently.
 
 This compression format is new in v3 of the specification.
 
-=item 4
+=item Z<>4
 
 Compressed Sereal format, using Zstandard compression internally as
 format I<4>.


### PR DESCRIPTION
Fixes #216, and a few other POD warnings found by running
```
find . -type f \( -iname '*.pl' -o -iname '*.pm' -o -iname '*.pod' \) \
    | xargs -l podchecker -warnings -warnings -warnings 2>&1 \
    | egrep 'WARN|ERROR'
```

The above Bash spell is perhaps a good candidate for inclusion in CI to catch POD errors and warnings.