### PR TITLE
Added documentation about object_factory

### DIFF
--- a/Python/README.md
+++ b/Python/README.md
@@ -10,6 +10,14 @@ Basic implementation of the Sereal protocol in Python.
 
 ### Decoder behaviour settings
 
+    object_factory: Function to customize the construction of an object.
+        The default function is:
+        def _default_object_factory(classname, data):
+            return {
+                'class': classname,
+                'object': data,
+            }
+
     bin_mode_classic: Specify the binary mode to use when decoding BINARY tags.
         If bin_mode_classic is True the decoder will auto decode all BINARY tags as UTF-8 encoded
         If bin_mode_classic is False the decoder will read BINARY tags verbatim


### PR DESCRIPTION
This parameter was introduced in
d0c4e0598bbc1f87ca0520f560c3a5825379d15c, but no documentation was added
to the README back then.

This change was extracted from #215. I think that PR tried too many things at once.