### PR TITLE
Moved bin_mode_classic from **kwargs into a proper named parameter

### DIFF
--- a/Python/sereal/constants.py
+++ b/Python/sereal/constants.py
@@ -27,5 +27,3 @@ SRL_TYPE_TRUE                       = 59
 SRL_TYPE_ARRAYREF_0                 = 64
 SRL_TYPE_HASHREF_0                  = 80
 SRL_TYPE_SHORT_BINARY_0             = 96
-
-SETTING_BIN_MODE_CLASSIC = 'bin_mode_classic'

--- a/Python/sereal/decoder.py
+++ b/Python/sereal/decoder.py
@@ -9,17 +9,8 @@ from sereal import exception
 
 
 class SrlDecoder(object):
-    def __init__(self, object_factory=None, **settings):
+    def __init__(self, object_factory=None, bin_mode_classic=True):
         super(SrlDecoder, self).__init__()
-
-        # default decode behaviour settings
-        self.settings = {
-            const.SETTING_BIN_MODE_CLASSIC: True
-        }
-
-        for k in self.settings:
-            if k in settings:
-                self.settings[k] = settings[k]
 
         self.header = {
             'version': None,
@@ -31,6 +22,7 @@ class SrlDecoder(object):
         self.body_offset = 0
         self.copy_depth = 0
         self.object_factory = object_factory if object_factory is not None else self._default_object_factory
+        self.bin_mode_classic = bin_mode_classic
 
     def decode(self, byte_str):
         self.reader = reader.SrlDocumentReader(byte_str)
@@ -222,14 +214,14 @@ class SrlDecoder(object):
 
     def _decode_binary(self):
         ln = self.reader.read_varint()
-        if self.settings[const.SETTING_BIN_MODE_CLASSIC]:
+        if self.bin_mode_classic:
             return self.reader.read_str(ln)
         else:
             return self.reader.read_bin(ln)
 
     def _decode_short_binary(self, tag):
         ln = tag & const.SRL_SHORT_BINARY_LEN
-        if self.settings[const.SETTING_BIN_MODE_CLASSIC]:
+        if self.bin_mode_classic:
             return self.reader.read_str(ln)
         else:
             return self.reader.read_bin(ln)


### PR DESCRIPTION
Follow-up of 49890e7fe415987c60588b3551f277113b76e869 and
df33d1c458d3baeb3c34ef319f30b940688a1964.

Python has named parameters, I don't think we need to pass an extra dict
with settings. Just pass it as a normal parameter. Also, just store that
as a plain attribute into this instance, which is simpler to write,
simpler to read, and simpler to understand.

In addition, this commit will make the Python interpreter throw an error
if an invalid parameter is passed, instead of silently ignoring it.

This was originally part of #215, but now I'm preferring to send smaller PRs that are easier to understand.