### PR TITLE
go: don't fail when unmarshalling null map values to map[string]interface{}

### DIFF
--- a/Go/sereal/decode.go
+++ b/Go/sereal/decode.go
@@ -695,7 +695,9 @@ func (d *Decoder) decodeViaReflection(by []byte, idx int, ptr reflect.Value) (in
 		var iface interface{}
 		var err error
 		idx, err = d.decode(by, idx, &iface)
-		ptr.Set(reflect.ValueOf(iface))
+		if iface != nil {
+			ptr.Set(reflect.ValueOf(iface))
+		}
 		return idx, err
 	}
 

--- a/Go/sereal/sereal_test.go
+++ b/Go/sereal/sereal_test.go
@@ -85,7 +85,7 @@ func testRoundtrip(t *testing.T, perlCompat bool, version int) {
 			_ = vt // avoid "declared but not used"
 
 		case []interface{}:
-			unSlice := make([]interface{}, 0)
+			var unSlice []interface{}
 			err = d.Unmarshal(b, &unSlice)
 			if err != nil {
 				t.Errorf("error during unmarshal: %s\n", err)
@@ -95,7 +95,7 @@ func testRoundtrip(t *testing.T, perlCompat bool, version int) {
 			}
 
 		case map[string]interface{}:
-			unMap := make(map[string]interface{}, 0)
+			var unMap map[string]interface{}
 			err = d.Unmarshal(b, &unMap)
 			if err != nil {
 				t.Errorf("error during unmarshal: %s\n", err)


### PR DESCRIPTION
Unmarshalling any map with null values in the root, like {"foo":null}, would fail if unmarshalled to map[string]interface{} instead of interface{} - which is a common and perfectly valid usecase.

This change fixes it and add tests for it.