### PR TITLE
Go: don't corrupt input when unmarshalling compressed data

### DIFF
--- a/Go/sereal/decode.go
+++ b/Go/sereal/decode.go
@@ -225,10 +225,10 @@ func (d *Decoder) UnmarshalHeaderBody(b []byte, vheader interface{}, vbody inter
 				return err
 			}
 
-			// shrink down b to reuse the allocated buffer
-			b = b[:0]
-			b = append(b, b[:bodyStart]...)
-			b = append(b, decompBody...)
+			newBody := make([]byte, 0, len(b[:bodyStart])+len(decompBody))
+			newBody = append(newBody, b[:bodyStart]...)
+			newBody = append(newBody, decompBody...)
+			b = newBody
 		}
 
 		d.tracked = make(map[int]reflect.Value)


### PR DESCRIPTION
As of now, UnmarshalHeaderBody() tries to reuse the original slice when unmarshalling decompressed data - so that if the slice with the compressed data has enough capacity to hold the uncompressed variant, no extra allocation will happen.

Which leads to a very surprising behaviour: if you have a compressed sereal document in a slice with extra capacity, then you can unmarshal it only once, as unmarshalling changes the underlying slice and does not return a new correct version of it. This is, roughly, what you end up with:

```
input before unmarshal, with compression: [ "fo*10ba*10r",             len=11, cap=100 ]  <- valid
after decomp in UnmarshalHeaderBody():    [ "foooooooooobaaaaaaaaaar", len=23, cap=100 ]  <- valid
input after unmarshal:                    [ "foooooooooo",             len=11, cap=100 ]  <- corrupted
```

This commit removes this optimization, for the sake of sanity of developers working with the library.

Alternatives to removing it are having a flag like `ReuseInput` in sereal.Decoder struct or changing API so that Unmarshal() calls would return the new version of input, like append() does