### PR TITLE
Updated Java dependencies

### DIFF
--- a/Java/benchmarks/pom.xml
+++ b/Java/benchmarks/pom.xml
@@ -14,7 +14,7 @@
     <name>JMH benchmark sample: Java</name>
 
     <properties>
-        <jmh.version>1.21</jmh.version>
+        <jmh.version>1.23</jmh.version>
         <uberjar.name>benchmarks</uberjar.name>
     </properties>
 

--- a/Java/benchmarks/pom.xml
+++ b/Java/benchmarks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.booking.sereal</groupId>
         <artifactId>parent</artifactId>
-        <version>0.0.2-SNAPSHOT</version>
+        <version>0.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>benchmarks</artifactId>

--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -4,14 +4,21 @@
 
     <groupId>com.booking.sereal</groupId>
     <artifactId>parent</artifactId>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.0.4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+
+        <jackson.version>2.11.1</jackson.version>
     </properties>
+
+    <scm>
+        <connection>scm:git:ssh://github.com/Sereal/Sereal.git</connection>
+        <url>https://github.com/Sereal/Sereal.git</url>
+    </scm>
 
     <modules>
         <module>sereal</module>
@@ -23,33 +30,35 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>2.9.9</version>
+                <version>${jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.9.10.3</version>
+                <version>${jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.xerial.snappy</groupId>
                 <artifactId>snappy-java</artifactId>
-                <version>1.1.7.3</version>
+                <version>1.1.7.6</version>
             </dependency>
             <dependency>
                 <groupId>com.github.luben</groupId>
                 <artifactId>zstd-jni</artifactId>
-                <version>1.4.0-1</version>
+                <version>1.4.4-1</version>
             </dependency>
 
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.12</version>
+                <version>4.13</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest</artifactId>
-                <version>2.1</version>
+                <version>2.2</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -60,17 +69,17 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.0.0-M2</version>
+                    <version>3.0.0-M3</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.2.1</version>
+                    <version>3.241</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.0</version>
+                    <version>3.8.1</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -98,8 +107,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <!-- this version fixes bug https://issues.apache.org/jira/browse/SUREFIRE-1588 -->
-                <version>3.0.0-M1</version>
+                <version>3.0.0-M4</version>
             </plugin>
         </plugins>
     </build>

--- a/Java/sereal-jackson-dataformat/pom.xml
+++ b/Java/sereal-jackson-dataformat/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.booking.sereal</groupId>
         <artifactId>parent</artifactId>
-        <version>0.0.2-SNAPSHOT</version>
+        <version>0.0.4-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/Java/sereal/pom.xml
+++ b/Java/sereal/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.booking.sereal</groupId>
         <artifactId>parent</artifactId>
-        <version>0.0.2-SNAPSHOT</version>
+        <version>0.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>sereal</artifactId>


### PR DESCRIPTION
Upgraded Jackson and Snappy dependencies to the newer version
Upgraded ZSTD-JNI to version `1.4.4-1` upgrade to `1.4.5-1` will need to wait to https://github.com/luben/zstd-jni/issues/126 be fixed
Upgraded other maven plugin versions

Bumped Sereal version to 0.0.4-SNAPSHOT since there was an internal 0.0.3 release.