### PR TITLE
Control how large can be some data structures in Java

### DIFF
--- a/Java/sereal/src/main/java/com/booking/sereal/Decoder.java
+++ b/Java/sereal/src/main/java/com/booking/sereal/Decoder.java
@@ -40,6 +40,11 @@ public class Decoder implements SerealHeader {
   private final boolean useObjectArray;
   private final int decodeBufferSize;
   private final int maxSize;
+
+  private final int maxRecursionDepth;
+  private final int maxNumMapEntries;
+  private final int maxNumArrayEntries;
+
   private byte[] data;
   private int position, end;
   private ByteArray originalData;
@@ -51,6 +56,8 @@ public class Decoder implements SerealHeader {
   private long userHeaderPosition = -1;
   private long userHeaderSize = -1;
   private Inflater inflater;
+
+  private int recursionDepth = 0;
 
   /** Create a new Decoder with default options. */
   public Decoder() {
@@ -70,7 +77,11 @@ public class Decoder implements SerealHeader {
     typeMapper = options.typeMapper();
     useObjectArray = typeMapper.useObjectArray();
     decodeBufferSize = options.bufferSize();
-    maxSize = options.maxSize();
+    maxSize = options.maxBufferSize();
+
+    maxRecursionDepth = options.maxRecursionDepth();
+    maxNumMapEntries = options.maxNumMapEntries();
+    maxNumArrayEntries = options.maxNumArrayEntries();
   }
 
   private void checkHeader() throws SerealException {
@@ -191,6 +202,8 @@ public class Decoder implements SerealHeader {
    */
   public Object decode() throws SerealException {
 
+    recursionDepth = 0;
+
     if (data == null) {
       throw new SerealException("No data set");
     }
@@ -273,8 +286,6 @@ public class Decoder implements SerealHeader {
       this.data = outputStream.toByteArray();
     } catch (DataFormatException | IOException e) {
       throw new SerealException(e);
-    } finally {
-      inflater.end();
     }
     this.position = 0;
     this.end = this.data.length;
@@ -309,6 +320,10 @@ public class Decoder implements SerealHeader {
    * @param track we might need to track since array elements could refer to us
    */
   private Object[] readNativeArray(int length, int track) throws SerealException {
+    if (maxNumArrayEntries != 0 && length > maxNumArrayEntries) {
+      throw new SerealException("Got input array with " + length + " entries, but the configured maximum is just " + maxNumArrayEntries);
+    }
+
     Object[] out = new Object[length];
     if (track != 0) { // track ourself
       track_stuff(track, out);
@@ -328,6 +343,11 @@ public class Decoder implements SerealHeader {
    * @param track we might need to track since array elements could refer to us
    */
   private List<Object> readList(int length, int track) throws SerealException {
+
+    if (maxNumArrayEntries != 0 && length > maxNumArrayEntries) {
+      throw new SerealException("Got input array with " + length + " entries, but the configured maximum is just " + maxNumArrayEntries);
+    }
+
     List<Object> out = typeMapper.makeArray(length);
     if (track != 0) { // track ourself
       track_stuff(track, out);
@@ -355,6 +375,11 @@ public class Decoder implements SerealHeader {
   }
 
   private Map<String, Object> readMap(int num_keys, int track) throws SerealException {
+
+    if (maxNumMapEntries != 0 && num_keys > maxNumMapEntries) {
+      throw new SerealException("Got input hash with " + num_keys + " entries, but the configured maximum is just " + maxNumMapEntries);
+    }
+
     Map<String, Object> hash = typeMapper.makeMap((int) num_keys);
     if (track != 0) { // track ourself
       track_stuff(track, hash);
@@ -417,13 +442,19 @@ public class Decoder implements SerealHeader {
         out = preferLatin1 ? new Latin1String(short_binary) : short_binary;
       }
     } else if ((tag & SRL_HDR_HASHREF) == SRL_HDR_HASHREF) {
+      depthIncrement();
+
       Map<String, Object> hash = readMap(tag & 0xf, track);
       if (perlRefs) {
         out = new PerlReference(hash);
       } else {
         out = hash;
       }
+
+      depthDecrement();
     } else if ((tag & SRL_HDR_ARRAYREF) == SRL_HDR_ARRAYREF) {
+      depthIncrement();
+
       Object arr;
       if (useObjectArray) {
         arr = readNativeArray(tag & 0xf, track);
@@ -435,6 +466,8 @@ public class Decoder implements SerealHeader {
       } else {
         out = arr;
       }
+
+      depthDecrement();
     } else {
       switch (tag) {
         case SRL_HDR_VARINT:
@@ -506,6 +539,8 @@ public class Decoder implements SerealHeader {
           out = utf8;
           break;
         case SRL_HDR_REFN:
+          depthIncrement();
+
           if (perlRefs) {
             PerlReference refn = new PerlReference(null);
             // track early for weak references
@@ -517,6 +552,8 @@ public class Decoder implements SerealHeader {
           } else {
             out = readSingleValue();
           }
+
+          depthDecrement();
           break;
         case SRL_HDR_REFP:
           long offset_prev = read_varint();
@@ -802,5 +839,17 @@ public class Decoder implements SerealHeader {
 
   private void resetTracked() {
     tracked.clear();
+  }
+
+  private void depthIncrement() throws SerealException {
+    ++recursionDepth;
+
+    if (recursionDepth > maxRecursionDepth) {
+      throw new SerealException("Reached recursion limit (" + maxRecursionDepth + ") during deserialization");
+    }
+  }
+
+  private void depthDecrement() {
+    recursionDepth--;
   }
 }

--- a/Java/sereal/src/main/java/com/booking/sereal/Decoder.java
+++ b/Java/sereal/src/main/java/com/booking/sereal/Decoder.java
@@ -44,6 +44,7 @@ public class Decoder implements SerealHeader {
   private final int maxRecursionDepth;
   private final int maxNumMapEntries;
   private final int maxNumArrayEntries;
+  private final int maxStringLength;
 
   private byte[] data;
   private int position, end;
@@ -82,6 +83,7 @@ public class Decoder implements SerealHeader {
     maxRecursionDepth = options.maxRecursionDepth();
     maxNumMapEntries = options.maxNumMapEntries();
     maxNumArrayEntries = options.maxNumArrayEntries();
+    maxStringLength = options.maxStringLength();
   }
 
   private void checkHeader() throws SerealException {
@@ -694,11 +696,15 @@ public class Decoder implements SerealHeader {
     return copy;
   }
 
-  private String read_UTF8() {
+  private String read_UTF8() throws SerealException {
     int length = (int) read_varint();
     int originalPosition = position;
 
     position += length;
+
+    if (maxStringLength != 0 && length > maxStringLength) {
+      throw new SerealException("Got input string with " + length + " characters, but the configured maximum is just " + maxStringLength);
+    }
 
     return new String(data, originalPosition, length, charset_utf8);
   }

--- a/Java/sereal/src/main/java/com/booking/sereal/DecoderOptions.java
+++ b/Java/sereal/src/main/java/com/booking/sereal/DecoderOptions.java
@@ -10,6 +10,10 @@ public class DecoderOptions {
   private boolean stripObjects = false;
   private boolean forceJavaStringForByteArrayValues = false;
 
+  private int maxRecursionDepth = 10_000;
+  private int maxNumMapEntries = 10_000;
+  private int maxNumArrayEntries = 10_000;
+
   // Size to use on the buffer used to read the data. Defaults to 1KB
   private int decodeBufferSize = 1024;
   // Maximum size allowed for the data. Defaults to 100MB
@@ -57,8 +61,54 @@ public class DecoderOptions {
     return decodeBufferSize;
   }
 
-  public int maxSize() {
+  public int maxBufferSize() {
     return maxSize;
+  }
+
+  /**
+   * {@link Decoder} is recursive. If you pass it a Sereal document that is deeply
+   * nested, it will eventually exhaust the C stack. Therefore, there is a limit on
+   * the depth of recursion that is accepted. It defaults to 10000 nested calls. You
+   * may choose to override this value with the {@link DecoderOptions#maxRecursionDepth(int)} option.
+   * Beware that setting it too high can cause hard crashes.
+   *
+   * Do note that the setting is somewhat approximate. Setting it to 10000 may break at
+   * somewhere between 9997 and 10003 nested structures depending on their types.
+   *
+   * @return maximum recursion depth
+   */
+  public int maxRecursionDepth() {
+    return maxRecursionDepth;
+  }
+
+  /**
+   * If set to a non-zero value (default: 10000), then {@link Decoder} will refuse
+   * to deserialize any hash/dictionary (or hash-based object) with more than
+   * that number of entries. This is to be able to respond quickly to any future
+   * hash-collision attacks on Perl's hash function. Chances are, you don't want
+   * or need this. For a gentle introduction to the topic from the cryptographic
+   * point of view, see <a href="http://en.wikipedia.org/wiki/Collision_attack"/>.
+   *
+   * This value can be override with {@link DecoderOptions#maxNumMapEntries(int)} option
+   *
+   * @return maximum number of map entries
+   */
+  public int maxNumMapEntries() {
+    return maxNumMapEntries;
+  }
+
+  /**
+   * If set to a non-zero value (default: 10000), then {@link Decoder} will refuse
+   * to deserialize any array with more than that number of entries.
+   * This is to be able to respond quickly to any future memory exhaustion attacks on
+   * Sereal.
+   *
+   * This value can be override with {@link DecoderOptions#maxNumArrayEntries(int)} option
+   *
+   * @return maximum number of array entries
+   */
+  public int maxNumArrayEntries() {
+    return maxNumArrayEntries;
   }
 
   public DecoderOptions perlReferences(boolean perlReferences) {
@@ -123,6 +173,24 @@ public class DecoderOptions {
 
   public DecoderOptions maxBufferSize(int maxSize) {
     this.maxSize = maxSize;
+
+    return this;
+  }
+
+  public DecoderOptions maxRecursionDepth(int maxRecursionDepth) {
+    this.maxRecursionDepth = maxRecursionDepth;
+
+    return this;
+  }
+
+  public DecoderOptions maxNumMapEntries(int maxNumMapEntries) {
+    this.maxNumMapEntries = maxNumMapEntries;
+
+    return this;
+  }
+
+  public DecoderOptions maxNumArrayEntries(int maxNumArrayEntries) {
+    this.maxNumArrayEntries = maxNumArrayEntries;
 
     return this;
   }

--- a/Java/sereal/src/main/java/com/booking/sereal/DecoderOptions.java
+++ b/Java/sereal/src/main/java/com/booking/sereal/DecoderOptions.java
@@ -11,8 +11,9 @@ public class DecoderOptions {
   private boolean forceJavaStringForByteArrayValues = false;
 
   private int maxRecursionDepth = 10_000;
-  private int maxNumMapEntries = 10_000;
-  private int maxNumArrayEntries = 10_000;
+  private int maxNumMapEntries = 0;
+  private int maxNumArrayEntries = 0;
+  private int maxStringLength = 0;
 
   // Size to use on the buffer used to read the data. Defaults to 1KB
   private int decodeBufferSize = 1024;
@@ -82,7 +83,7 @@ public class DecoderOptions {
   }
 
   /**
-   * If set to a non-zero value (default: 10000), then {@link Decoder} will refuse
+   * If set to a non-zero value (default: 0), then {@link Decoder} will refuse
    * to deserialize any hash/dictionary (or hash-based object) with more than
    * that number of entries. This is to be able to respond quickly to any future
    * hash-collision attacks on Perl's hash function. Chances are, you don't want
@@ -98,7 +99,7 @@ public class DecoderOptions {
   }
 
   /**
-   * If set to a non-zero value (default: 10000), then {@link Decoder} will refuse
+   * If set to a non-zero value (default: 0), then {@link Decoder} will refuse
    * to deserialize any array with more than that number of entries.
    * This is to be able to respond quickly to any future memory exhaustion attacks on
    * Sereal.
@@ -109,6 +110,20 @@ public class DecoderOptions {
    */
   public int maxNumArrayEntries() {
     return maxNumArrayEntries;
+  }
+
+  /**
+   * If set to a non-zero value (default: 0), then {@link Decoder} will refuse
+   * to deserialize any string with more than that number of characters.
+   * This is to be able to respond quickly to any future memory exhaustion attacks on
+   * Sereal.
+   *
+   * This value can be override with {@link DecoderOptions#maxStringLength(int)} option
+   *
+   * @return maximum supported string length
+   */
+  public int maxStringLength() {
+    return maxStringLength;
   }
 
   public DecoderOptions perlReferences(boolean perlReferences) {
@@ -191,6 +206,12 @@ public class DecoderOptions {
 
   public DecoderOptions maxNumArrayEntries(int maxNumArrayEntries) {
     this.maxNumArrayEntries = maxNumArrayEntries;
+
+    return this;
+  }
+
+  public DecoderOptions maxStringLength(int maxStringLength) {
+    this.maxStringLength = maxStringLength;
 
     return this;
   }

--- a/Java/sereal/src/main/java/com/booking/sereal/Encoder.java
+++ b/Java/sereal/src/main/java/com/booking/sereal/Encoder.java
@@ -40,6 +40,11 @@ public class Encoder {
   private final long compressionThreshold;
   private final Deflater deflater;
   private final int zstdCompressionLevel;
+
+  private final int maxRecursionDepth;
+  private final int maxNumMapEntries;
+  private final int maxNumArrayEntries;
+
   private final byte[] HEADER =
       new byte[] {
         (byte) (SerealHeader.MAGIC >> 24),
@@ -70,6 +75,8 @@ public class Encoder {
   private int headerSize, headerOffset;
   private Charset charset_utf8 = Charset.forName("UTF-8");
 
+  private int recursionDepth = 0;
+
   /** Create a new Encoder with default options. */
   public Encoder() {
     this(DEFAULT_OPTIONS);
@@ -83,6 +90,10 @@ public class Encoder {
     compressionType = options.compressionType();
     compressionThreshold = options.compressionThreshold();
     zstdCompressionLevel = options.zstdCompressionLevel();
+
+    maxRecursionDepth = options.maxRecursionDepth();
+    maxNumMapEntries = options.maxNumMapEntries();
+    maxNumArrayEntries = options.maxNumArrayEntries();
 
     switch (protocolVersion) {
       case 4:
@@ -505,6 +516,8 @@ public class Encoder {
     // track it (for ALIAS tags)
     long location = size;
 
+    depthIncrement();
+
     if (perlAlias) {
       long aliasOffset = aliases.get(obj);
       if (aliasOffset != IdentityMap.NOT_FOUND) {
@@ -611,6 +624,8 @@ public class Encoder {
       if (perlRefs || !tryAppendRefp(obj)) appendArray((List<Object>) obj);
     }
 
+    depthDecrement();
+
     if (size == location) { // didn't write anything
       throw new SerealException(
           "Don't know how to encode: " + type.getName() + " = " + obj.toString());
@@ -706,6 +721,11 @@ public class Encoder {
   }
 
   private void appendMap(Map<Object, Object> hash) throws SerealException {
+
+    if (maxNumMapEntries != 0 && hash.size() > maxNumMapEntries) {
+      throw new SerealException("Got input hash with " + hash.size() + " entries, but the configured maximum is just " + maxNumMapEntries);
+    }
+
     if (!perlRefs) {
       appendByte(SerealHeader.SRL_HDR_REFN);
       track(hash, size);
@@ -731,6 +751,10 @@ public class Encoder {
     // checking length without casting to Object[] since they might primitives
     int count = Array.getLength(obj);
 
+    if (maxNumArrayEntries != 0 && count > maxNumArrayEntries) {
+      throw new SerealException("Got input array with " + count + " entries, but the configured maximum is just " + maxNumArrayEntries);
+    }
+
     if (!perlRefs) {
       appendByte(SerealHeader.SRL_HDR_REFN);
       track(obj, size);
@@ -747,6 +771,10 @@ public class Encoder {
   private void appendArray(Object[] array) throws SerealException {
     int count = array.length;
 
+    if (maxNumArrayEntries != 0 && count > maxNumArrayEntries) {
+      throw new SerealException("Got input array with " + count + " entries, but the configured maximum is just " + maxNumArrayEntries);
+    }
+
     if (!perlRefs) {
       appendByte(SerealHeader.SRL_HDR_REFN);
       track(array, size);
@@ -761,6 +789,10 @@ public class Encoder {
 
   private void appendArray(List<Object> list) throws SerealException {
     int count = list.size();
+
+    if (maxNumArrayEntries != 0 && count > maxNumArrayEntries) {
+      throw new SerealException("Got input array with " + count + " entries, but the configured maximum is just " + maxNumArrayEntries);
+    }
 
     if (!perlRefs) {
       appendByte(SerealHeader.SRL_HDR_REFN);
@@ -870,7 +902,7 @@ public class Encoder {
 
   /** Discard all previous tracking clear the buffers etc Call this when you reuse the encoder */
   private void reset() {
-    size = compressedSize = headerSize = 0;
+    size = compressedSize = headerSize = recursionDepth = 0;
     resetTracked();
   }
 
@@ -919,5 +951,17 @@ public class Encoder {
   private void appendByteUnsafe(byte data) {
     bytes[(int) size] = data;
     size++;
+  }
+
+  private void depthIncrement() throws SerealException {
+    ++recursionDepth;
+
+    if (recursionDepth > maxRecursionDepth) {
+      throw new SerealException("Reached recursion limit (" + maxRecursionDepth + ") during deserialization");
+    }
+  }
+
+  private void depthDecrement() {
+    recursionDepth--;
   }
 }

--- a/Java/sereal/src/main/java/com/booking/sereal/Encoder.java
+++ b/Java/sereal/src/main/java/com/booking/sereal/Encoder.java
@@ -44,6 +44,7 @@ public class Encoder {
   private final int maxRecursionDepth;
   private final int maxNumMapEntries;
   private final int maxNumArrayEntries;
+  private final int maxStringLength;
 
   private final byte[] HEADER =
       new byte[] {
@@ -94,6 +95,7 @@ public class Encoder {
     maxRecursionDepth = options.maxRecursionDepth();
     maxNumMapEntries = options.maxNumMapEntries();
     maxNumArrayEntries = options.maxNumArrayEntries();
+    maxStringLength = options.maxStringLength();
 
     switch (protocolVersion) {
       case 4:
@@ -824,6 +826,10 @@ public class Encoder {
   }
 
   private void appendStringType(String str) throws SerealException {
+    if (maxStringLength != 0 && str.length() > maxStringLength) {
+      throw new SerealException("Got input string with " + str.length() + " characters, but the configured maximum is just " + maxStringLength);
+    }
+
     // maybe we can just COPY
     long copyOffset = getTrackedItemCopy(str);
     if (copyOffset != StringCopyMap.NOT_FOUND) {

--- a/Java/sereal/src/main/java/com/booking/sereal/EncoderOptions.java
+++ b/Java/sereal/src/main/java/com/booking/sereal/EncoderOptions.java
@@ -9,6 +9,10 @@ public class EncoderOptions {
   private int zlibCompressionLevel = 6;
   private int zstdCompressionLevel = 3;
 
+  private int maxRecursionDepth = 10_000;
+  private int maxNumMapEntries = 10_000;
+  private int maxNumArrayEntries = 10_000;
+
   public boolean perlReferences() {
     return perlRefs;
   }
@@ -35,6 +39,52 @@ public class EncoderOptions {
 
   public int zstdCompressionLevel() {
     return zstdCompressionLevel;
+  }
+
+  /**
+   * {@link Encoder} is recursive. If you pass it an Object that is deeply
+   * nested, it will eventually exhaust the C stack. Therefore, there is a limit on
+   * the depth of recursion that is accepted. It defaults to 10000 nested calls. You
+   * may choose to override this value with the {@link EncoderOptions#maxRecursionDepth(int)} option.
+   * Beware that setting it too high can cause hard crashes.
+   *
+   * Do note that the setting is somewhat approximate. Setting it to 10000 may break at
+   * somewhere between 9997 and 10003 nested structures depending on their types.
+   *
+   * @return maximum recursion depth
+   */
+  public int maxRecursionDepth() {
+    return maxRecursionDepth;
+  }
+
+  /**
+   * If set to a non-zero value (default: 10000), then {@link Encoder} will refuse
+   * to deserialize any hash/dictionary (or hash-based object) with more than
+   * that number of entries. This is to be able to respond quickly to any future
+   * hash-collision attacks on Perl's hash function. Chances are, you don't want
+   * or need this. For a gentle introduction to the topic from the cryptographic
+   * point of view, see <a href="http://en.wikipedia.org/wiki/Collision_attack"/>.
+   *
+   * This value can be override with {@link EncoderOptions#maxNumMapEntries(int)} option
+   *
+   * @return maximum number of map entries
+   */
+  public int maxNumMapEntries() {
+    return maxNumMapEntries;
+  }
+
+  /**
+   * If set to a non-zero value (default: 10000), then {@link Encoder} will refuse
+   * to deserialize any array with more than that number of entries.
+   * This is to be able to respond quickly to any future memory exhaustion attacks on
+   * Sereal.
+   *
+   * This value can be override with {@link EncoderOptions#maxNumArrayEntries(int)} option
+   *
+   * @return maximum number of array entries
+   */
+  public int maxNumArrayEntries() {
+    return maxNumArrayEntries;
   }
 
   public EncoderOptions perlReferences(boolean perlReferences) {
@@ -81,6 +131,25 @@ public class EncoderOptions {
 
   public EncoderOptions zstdCompressionLevel(int zstdCompressionLevel) {
     this.zstdCompressionLevel = zstdCompressionLevel;
+    return this;
+  }
+
+
+  public EncoderOptions maxRecursionDepth(int maxRecursionDepth) {
+    this.maxRecursionDepth = maxRecursionDepth;
+
+    return this;
+  }
+
+  public EncoderOptions maxNumMapEntries(int maxNumMapEntries) {
+    this.maxNumMapEntries = maxNumMapEntries;
+
+    return this;
+  }
+
+  public EncoderOptions maxNumArrayEntries(int maxNumArrayEntries) {
+    this.maxNumArrayEntries = maxNumArrayEntries;
+
     return this;
   }
 

--- a/Java/sereal/src/main/java/com/booking/sereal/EncoderOptions.java
+++ b/Java/sereal/src/main/java/com/booking/sereal/EncoderOptions.java
@@ -10,8 +10,9 @@ public class EncoderOptions {
   private int zstdCompressionLevel = 3;
 
   private int maxRecursionDepth = 10_000;
-  private int maxNumMapEntries = 10_000;
-  private int maxNumArrayEntries = 10_000;
+  private int maxNumMapEntries = 0;
+  private int maxNumArrayEntries = 0;
+  private int maxStringLength = 0;
 
   public boolean perlReferences() {
     return perlRefs;
@@ -58,7 +59,7 @@ public class EncoderOptions {
   }
 
   /**
-   * If set to a non-zero value (default: 10000), then {@link Encoder} will refuse
+   * If set to a non-zero value (default: 0), then {@link Encoder} will refuse
    * to deserialize any hash/dictionary (or hash-based object) with more than
    * that number of entries. This is to be able to respond quickly to any future
    * hash-collision attacks on Perl's hash function. Chances are, you don't want
@@ -74,8 +75,8 @@ public class EncoderOptions {
   }
 
   /**
-   * If set to a non-zero value (default: 10000), then {@link Encoder} will refuse
-   * to deserialize any array with more than that number of entries.
+   * If set to a non-zero value (default: 0), then {@link Encoder} will refuse
+   * to serialize any array with more than that number of entries.
    * This is to be able to respond quickly to any future memory exhaustion attacks on
    * Sereal.
    *
@@ -85,6 +86,20 @@ public class EncoderOptions {
    */
   public int maxNumArrayEntries() {
     return maxNumArrayEntries;
+  }
+
+  /**
+   * If set to a non-zero value (default: 0), then {@link Encoder} will refuse
+   * to deserialize any string with more than that number of characters.
+   * This is to be able to respond quickly to any future memory exhaustion attacks on
+   * Sereal.
+   *
+   * This value can be override with {@link EncoderOptions#maxStringLength(int)} option
+   *
+   * @return maximum supported string length
+   */
+  public int maxStringLength() {
+    return maxStringLength;
   }
 
   public EncoderOptions perlReferences(boolean perlReferences) {
@@ -149,6 +164,12 @@ public class EncoderOptions {
 
   public EncoderOptions maxNumArrayEntries(int maxNumArrayEntries) {
     this.maxNumArrayEntries = maxNumArrayEntries;
+
+    return this;
+  }
+
+  public EncoderOptions maxStringLength(int maxStringLength) {
+    this.maxStringLength = maxStringLength;
 
     return this;
   }

--- a/Java/sereal/src/test/java/com/booking/sereal/DecoderTest.java
+++ b/Java/sereal/src/test/java/com/booking/sereal/DecoderTest.java
@@ -2,14 +2,20 @@ package com.booking.sereal;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.booking.sereal.EncoderOptions.CompressionType;
 import java.lang.ref.WeakReference;
 import java.math.BigInteger;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
 import org.junit.Test;
 
 public class DecoderTest {
@@ -93,4 +99,87 @@ public class DecoderTest {
     assertThat(decoded, instanceOf(BigInteger.class));
     assertThat(decoded.toString(), equalTo("11781050652756758130"));
   }
+
+  @Test
+  public void testDecodeArrays() throws SerealException {
+    Encoder encoder = new Encoder();
+    Decoder decoder = new Decoder();
+
+    int size = 100;
+    List<String> stringArray = new ArrayList<>();
+    for (int i = 0; i < size; i++) {
+      stringArray.add(new String("Value " + i + " of the array"));
+    }
+    encoder.write(stringArray);
+    byte[] data = encoder.getData();
+
+    decoder.setData(data);
+    ArrayList<String> result = (ArrayList<String>) decoder.decode();
+
+    assertEquals(size, result.size());
+    for (int i = 0; i < size; i++) {
+      assertEquals("Value " + i + " of the array", result.get(i));
+    }
+  }
+
+  @Test
+  public void testDecodeTooLargeArrays() throws SerealException {
+    Encoder encoder = new Encoder();
+    Decoder decoder = new Decoder(new DecoderOptions().maxNumArrayEntries(100));
+
+    int size = 1000;
+    List<String> stringArray = new ArrayList<>();
+    for (int i = 0; i < size; i++) {
+      stringArray.add(new String("Value " + i + " of the array"));
+    }
+    encoder.write(stringArray);
+    byte[] data = encoder.getData();
+
+    decoder.setData(data);
+
+    Exception exception = Assert.assertThrows(SerealException.class, () -> decoder.decode());
+    assertEquals("Got input array with 1000 entries, but the configured maximum is just 100", exception.getMessage());
+  }
+
+  @Test
+  public void testDecodeHashMap() throws SerealException {
+    Encoder encoder = new Encoder();
+    Decoder decoder = new Decoder();
+
+    int size = 100;
+    Map<String, String> stringMap = new HashMap<>();
+    for (int i = 0; i < size; i++) {
+      stringMap.put(String.valueOf(i), "Value " + i + " of the map");
+    }
+    encoder.write(stringMap);
+    byte[] data = encoder.getData();
+
+    decoder.setData(data);
+    Map<String, String> result = (HashMap<String, String>) decoder.decode();
+
+    assertEquals(size, result.keySet().size());
+    for (int i = 0; i < size; i++) {
+      assertEquals("Value " + i + " of the map", result.get(String.valueOf(i)));
+    }
+  }
+
+  @Test
+  public void testDecodeTooLargeHashMap() throws SerealException {
+    Encoder encoder = new Encoder();
+    Decoder decoder = new Decoder(new DecoderOptions().maxNumMapEntries(100));
+
+    int size = 1000;
+    Map<String, String> stringMap = new HashMap<>();
+    for (int i = 0; i < size; i++) {
+      stringMap.put(String.valueOf(i), "Value " + i + " of the map");
+    }
+    encoder.write(stringMap);
+    byte[] data = encoder.getData();
+
+    decoder.setData(data);
+
+    Exception exception = Assert.assertThrows(SerealException.class, () -> decoder.decode());
+    assertEquals("Got input hash with 1000 entries, but the configured maximum is just 100", exception.getMessage());
+  }
+
 }

--- a/Java/sereal/src/test/java/com/booking/sereal/DecoderTest.java
+++ b/Java/sereal/src/test/java/com/booking/sereal/DecoderTest.java
@@ -182,4 +182,30 @@ public class DecoderTest {
     assertEquals("Got input hash with 1000 entries, but the configured maximum is just 100", exception.getMessage());
   }
 
+  @Test
+  public void testDecodeLargeStrings() throws SerealException {
+    Encoder encoder = new Encoder();
+    Decoder decoder = new Decoder(new DecoderOptions().maxStringLength(10));
+    String shortString = "OK";
+    encoder.write(shortString);
+    decoder.setData(encoder.getData());
+    String result = (String) decoder.decode();
+    assertEquals(shortString, result);
+
+    String largeString = "Lorem ipsum dolor sit amet";
+    encoder.write(largeString);
+    decoder.setData(encoder.getData());
+
+    Exception exception = Assert.assertThrows(SerealException.class, () -> decoder.decode());
+    assertEquals("Got input string with 26 characters, but the configured maximum is just 10", exception.getMessage());
+
+    encoder.write(new Object[]{
+            new String("abc"),
+            new String(largeString),
+            new String("xyz"),
+    });
+    decoder.setData(encoder.getData());
+    exception = Assert.assertThrows(SerealException.class, () -> decoder.decode());
+    assertEquals("Got input string with 26 characters, but the configured maximum is just 10", exception.getMessage());
+  }
 }

--- a/Java/sereal/src/test/java/com/booking/sereal/EncoderTest.java
+++ b/Java/sereal/src/test/java/com/booking/sereal/EncoderTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -419,5 +420,29 @@ public class EncoderTest {
 			res.put((String) items[i], items[i + 1]);
 
 		return res;
+	}
+
+	@Test
+	public void testEncodeTooLargeHashMap() {
+		Encoder encoder = new Encoder(new EncoderOptions().maxNumMapEntries(100));
+		int size = 1000;
+		Map<String, String> stringMap = new HashMap<>();
+		for (int i = 0; i < size; i++) {
+			stringMap.put(String.valueOf(i), "Value " + i + " of the map");
+		}
+		Exception exception = Assert.assertThrows(SerealException.class, () -> encoder.write(stringMap));
+		assertEquals("Got input hash with 1000 entries, but the configured maximum is just 100", exception.getMessage());
+	}
+
+	@Test
+	public void testEncodeTooLargeArrays() {
+		Encoder encoder = new Encoder(new EncoderOptions().maxNumArrayEntries(100));
+		int size = 1000;
+		List<String> stringArray = new ArrayList<>();
+		for (int i = 0; i < size; i++) {
+			stringArray.add(new String("Value " + i + " of the array"));
+		}
+		Exception exception = Assert.assertThrows(SerealException.class, () -> encoder.write(stringArray));
+		assertEquals("Got input array with 1000 entries, but the configured maximum is just 100", exception.getMessage());
 	}
 }

--- a/Java/sereal/src/test/java/com/booking/sereal/EncoderTest.java
+++ b/Java/sereal/src/test/java/com/booking/sereal/EncoderTest.java
@@ -445,4 +445,22 @@ public class EncoderTest {
 		Exception exception = Assert.assertThrows(SerealException.class, () -> encoder.write(stringArray));
 		assertEquals("Got input array with 1000 entries, but the configured maximum is just 100", exception.getMessage());
 	}
+
+	@Test
+	public void testEncodeLargeStrings() throws SerealException {
+		Encoder encoder = new Encoder(new EncoderOptions().maxStringLength(10));
+		String shortString = "OK";
+		encoder.write(shortString);
+
+		String largeString = "Lorem ipsum dolor sit amet";
+		Exception exception = Assert.assertThrows(SerealException.class, () -> encoder.write(largeString));
+		assertEquals("Got input string with 26 characters, but the configured maximum is just 10", exception.getMessage());
+
+		exception = Assert.assertThrows(SerealException.class, () -> encoder.write(new Object[]{
+				new String("abc"),
+				new String(largeString),
+				new String("xyz"),
+		}));
+		assertEquals("Got input string with 26 characters, but the configured maximum is just 10", exception.getMessage());
+	}
 }

--- a/Java/sereal/src/test/java/com/booking/sereal/ZipBombTest.java
+++ b/Java/sereal/src/test/java/com/booking/sereal/ZipBombTest.java
@@ -57,7 +57,7 @@ public class ZipBombTest {
                 .compressionThreshold(0)
                 .compressionType(EncoderOptions.CompressionType.SNAPPY));
         byte[] encoded = encoder.write(data).getData();
-        System.out.println("Sereal Begin       : " + bytesToHex(encoded, 25));
+        //System.out.println("Sereal Begin       : " + bytesToHex(encoded, 25));
         //System.out.println("Encoded data size is " + sizeFormat(encoded.length) + " bytes");
         //System.out.println("Compression ratio is " + sizeFormat(data.length / encoded.length));
 
@@ -232,14 +232,13 @@ public class ZipBombTest {
 
         //System.out.println("Encoded data size is " + sizeFormat(encoded.length) + " bytes");
         //System.out.println("Compression ratio is " + sizeFormat(data.length / encoded.length));
-
-        System.out.println("Sereal Begin       : " + bytesToHex(encoded, 15));
+        //System.out.println("Sereal Begin       : " + bytesToHex(encoded, 15));
 
         assertEquals(0x44, encoded[4]);
 
         // Lets validate we have the expected uncompress size: 100MB
-        assertEquals((byte) 0x97, encoded[6]);
-        assertEquals((byte) 0xCB, encoded[7]);
+        assertEquals((byte) 0x9F, encoded[6]);
+        assertEquals((byte) 0x99, encoded[7]);
 
         byte[] forgedArray = new byte[encoded.length - 4];
         System.arraycopy(encoded, 0, forgedArray, 0, 10);


### PR DESCRIPTION
Both `Encoder` and `Decoder` get new configuration options
* maxRecursionDepth: Controls how many nested objects we can deal with
* maxNumMapEntries: Controls how many keys can have a map
* maxNumArrayEntries: Controls how many items can be stored in a List

All those values default to 10K. Setting them to `0` means infinity.

Also fixed a bug introduced on a previous commit.