### PR TITLE
Fix max size for using snappy

### DIFF
--- a/Perl/Encoder/srl_encoder.c
+++ b/Perl/Encoder/srl_encoder.c
@@ -1008,7 +1008,7 @@ srl_dump_data_structure(pTHX_ srl_encoder_t *enc, SV *src, SV *user_header_src)
     { /* Have some sort of compression */
         ptrdiff_t sereal_header_len;
         STRLEN uncompressed_body_length;
-        const STRLEN max_len = 1 << 32 - 1;
+        const STRLEN max_len = (1L << 32) - 1;
 
         /* Alas, have to write entire packet first since the header length
          * will determine offsets. */


### PR DESCRIPTION
It was limited to 2**31 instead of 2**32-1 due to operator priority

Fixes #247