### PR TITLE
Added missing Decoder Options:

### DIFF
--- a/Java/sereal/src/main/java/com/booking/sereal/Decoder.java
+++ b/Java/sereal/src/main/java/com/booking/sereal/Decoder.java
@@ -32,6 +32,8 @@ public class Decoder implements SerealHeader {
   private final boolean perlAlias;
   private final boolean preserveUndef;
   private final boolean refuseSnappy;
+  private final boolean refuseZlib;
+  private final boolean refuseZstd;
   private final boolean preferLatin1;
   private final boolean forceJavaStringForByteArrayValues;
   private final boolean refuseObjects;
@@ -71,6 +73,8 @@ public class Decoder implements SerealHeader {
     perlAlias = options.perlAliases();
     preserveUndef = options.preserveUndef();
     refuseSnappy = options.refuseSnappy();
+    refuseZlib = options.refuseZlib();
+    refuseZstd = options.refuseZstd();
     preferLatin1 = options.preferLatin1();
     forceJavaStringForByteArrayValues = options.forceJavaStringForByteArrayValues();
     refuseObjects = options.refuseObjects();
@@ -146,6 +150,10 @@ public class Decoder implements SerealHeader {
     encoding = (protoAndFlags & ~15) >> 4;
     if ((encoding == 1 || encoding == 2) && refuseSnappy) {
       throw new SerealException("Unsupported encoding: Snappy");
+    } else if (encoding == 3 && refuseZlib) {
+      throw new SerealException("Unsupported encoding: Zlib");
+    } else if (encoding == 4 && refuseZstd) {
+      throw new SerealException("Unsupported encoding: Zstd");
     } else if (encoding == 4 && protocolVersion < 4) {
       throw new SerealException(
           "Unsupported encoding zstd for protocol version " + protocolVersion);

--- a/Java/sereal/src/main/java/com/booking/sereal/DecoderOptions.java
+++ b/Java/sereal/src/main/java/com/booking/sereal/DecoderOptions.java
@@ -7,6 +7,8 @@ public class DecoderOptions {
   private boolean preferLatin1 = false;
   private boolean refuseSnappy = false;
   private boolean refuseObjects = false;
+  private boolean refuseZlib = false;
+  private boolean refuseZstd = false;
   private boolean stripObjects = false;
   private boolean forceJavaStringForByteArrayValues = false;
 
@@ -38,12 +40,44 @@ public class DecoderOptions {
     return preferLatin1;
   }
 
+  /**
+   * If set, the decoder will refuse Snappy-compressed input data. This can be
+   * desirable for robustness.
+   *
+   * @return {@code True} if Snappy is refused, {@False} otherwise
+   */
   public boolean refuseSnappy() {
     return refuseSnappy;
   }
 
+  /**
+   * If set, the decoder will refuse deserializing any objects in the input stream and
+   * instead throw an exception.
+   *
+   * @return {@code True} if Objects are refused, {@False} otherwise
+   */
   public boolean refuseObjects() {
     return refuseObjects;
+  }
+
+  /**
+   * If set, the decoder will refuse Zlib-compressed input data. This can be
+   * desirable for robustness.
+   *
+   * @return {@code True} if Zlib is refused, {@False} otherwise
+   */
+  public boolean refuseZlib() {
+    return refuseZlib;
+  }
+
+  /**
+   * If set, the decoder will refuse Zstd-compressed input data. This can be
+   * desirable for robustness.
+   *
+   * @return {@code True} if Zstd is refused, {@False} otherwise
+   */
+  public boolean refuseZstd() {
+    return refuseZstd;
   }
 
   public boolean stripObjects() {
@@ -170,6 +204,18 @@ public class DecoderOptions {
 
   public DecoderOptions stripObjects(boolean stripObjects) {
     this.stripObjects = stripObjects;
+
+    return this;
+  }
+
+  public DecoderOptions refuseZlib(boolean refuseZlib) {
+    this.refuseZlib = refuseZlib;
+
+    return this;
+  }
+
+  public DecoderOptions refuseZstd(boolean refuseZstd) {
+    this.refuseZstd = refuseZstd;
 
     return this;
   }


### PR DESCRIPTION
* refuseZlib
* refuseZstd

Those options are available in Perl, but were missing in Java.