### PR TITLE
[go] Work with pointers to primitive types

### DIFF
--- a/Go/sereal/decode.go
+++ b/Go/sereal/decode.go
@@ -721,6 +721,7 @@ func (d *Decoder) decodeViaReflection(by []byte, idx int, ptr reflect.Value) (in
 	idx++
 
 	var err error
+
 	switch {
 	case tag < typeVARINT:
 		setInt(ptr, d.decodeInt(tag))
@@ -746,17 +747,30 @@ func (d *Decoder) decodeViaReflection(by []byte, idx int, ptr reflect.Value) (in
 		if val, idx, err = d.decodeFloat(by, idx); err != nil {
 			return 0, err
 		}
-		ptr.SetFloat(float64(val))
+		if ptr.Kind() == reflect.Ptr {
+			setPtrFloat(ptr, float64(val))
+		} else {
+			ptr.SetFloat(float64(val))
+		}
 
 	case tag == typeDOUBLE:
 		var val float64
 		if val, idx, err = d.decodeDouble(by, idx); err != nil {
 			return 0, err
 		}
-		ptr.SetFloat(val)
+		if ptr.Kind() == reflect.Ptr {
+			setPtrFloat(ptr, float64(val))
+		} else {
+			ptr.SetFloat(float64(val))
+		}
 
 	case tag == typeTRUE, tag == typeFALSE:
-		ptr.SetBool(tag == typeTRUE)
+		if ptr.Kind() == reflect.Ptr {
+			boolValue := tag == typeTRUE
+			ptr.Set(reflect.ValueOf(&boolValue))
+		} else {
+			ptr.SetBool(tag == typeTRUE)
+		}
 
 	case tag == typeBINARY:
 		var val []byte
@@ -1204,8 +1218,61 @@ func setInt(ptr reflect.Value, i int) {
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		ptr.SetUint(uint64(i))
 
+	case reflect.Ptr:
+		setPtrInt(ptr, i)
 	default:
+
 		panic(&reflect.ValueError{Method: "sereal.setInt", Kind: ptr.Kind()})
+	}
+}
+
+func setPtrFloat(ptr reflect.Value, f float64) {
+	switch ptr.Type().Elem().Kind() {
+	case reflect.Float32:
+		v := float32(f)
+		ptr.Set(reflect.ValueOf(&v))
+	case reflect.Float64:
+		v := float64(f)
+		ptr.Set(reflect.ValueOf(&v))
+	default:
+		panic(&reflect.ValueError{Method: "sereal.setPtrFloat", Kind: ptr.Type().Elem().Kind()})
+	}
+}
+
+func setPtrInt(ptr reflect.Value, i int) {
+	switch ptr.Type().Elem().Kind() {
+	case reflect.Int:
+		v := int(i)
+		ptr.Set(reflect.ValueOf(&v))
+	case reflect.Int8:
+		v := int8(i)
+		ptr.Set(reflect.ValueOf(&v))
+	case reflect.Int16:
+		v := int16(i)
+		ptr.Set(reflect.ValueOf(&v))
+	case reflect.Int32:
+		v := int32(i)
+		ptr.Set(reflect.ValueOf(&v))
+	case reflect.Int64:
+		v := int64(i)
+		ptr.Set(reflect.ValueOf(&v))
+	case reflect.Uint:
+		v := uint(i)
+		ptr.Set(reflect.ValueOf(&v))
+	case reflect.Uint8:
+		v := uint8(i)
+		ptr.Set(reflect.ValueOf(&v))
+	case reflect.Uint16:
+		v := uint16(i)
+		ptr.Set(reflect.ValueOf(&v))
+	case reflect.Uint32:
+		v := uint32(i)
+		ptr.Set(reflect.ValueOf(&v))
+	case reflect.Uint64:
+		v := uint64(i)
+		ptr.Set(reflect.ValueOf(&v))
+	default:
+		panic(&reflect.ValueError{Method: "sereal.setPtrInt", Kind: ptr.Type().Elem().Kind()})
 	}
 }
 

--- a/Go/sereal/sereal_test.go
+++ b/Go/sereal/sereal_test.go
@@ -309,7 +309,6 @@ func testCompressedArray(t *testing.T, name string, compression compressor) {
 }
 
 func TestStructs(t *testing.T) {
-
 	type A struct {
 		Name     string
 		Phone    string
@@ -345,6 +344,52 @@ func TestStructs(t *testing.T) {
 		pint   int
 	}
 
+	type PrimitivePointers struct {
+		ManyInts []*int
+		N        *int
+		U        *uint
+		I64      *int64
+		U64      *uint64
+		I32      *int32
+		U32      *uint32
+		I16      *int16
+		U16      *uint16
+		I8       *int8
+		U8       *uint8
+		F32      *float32
+		F64      *float64
+		B        *bool
+		BY       *byte
+	}
+
+	vi := int(-282)
+	vu := uint(282)
+	vi64 := int64(64)
+	vu64 := uint64(640)
+	vi32 := int32(32)
+	vu32 := uint32(320)
+	vi16 := int16(16)
+	vu16 := uint16(160)
+	vi8 := int8(8)
+	vu8 := uint8(80)
+	vf32 := float32(3200)
+	vf64 := float64(6400)
+	vb := true
+	vby := byte(128)
+
+	pfoo := PrimitivePointers{
+		[]*int{&vi, &vi, &vi, &vi, &vi, &vi, &vi, &vi},
+		&vi,
+		&vu,
+		&vi64, &vu64,
+		&vi32, &vu32,
+		&vi16, &vu16,
+		&vi8, &vu8,
+		&vf32, &vf64,
+		&vb,
+		&vby,
+	}
+
 	type ATags struct {
 		Name     string `sereal:"Phone"`
 		Phone    string `sereal:"Name"`
@@ -367,6 +412,21 @@ func TestStructs(t *testing.T) {
 		outvar   interface{}
 		expected interface{}
 	}{
+
+		{
+			"primitive pointers",
+			pfoo,
+			PrimitivePointers{},
+			pfoo,
+		},
+
+		{
+			"array of primitive pointer",
+			[]PrimitivePointers{pfoo, pfoo},
+			[]PrimitivePointers(nil),
+			[]PrimitivePointers{pfoo, pfoo},
+		},
+
 		{
 			"struct with fields",
 			Afoo,
@@ -430,7 +490,7 @@ func TestStructs(t *testing.T) {
 		{
 			"1-length slice of structs",
 			[]A{Afoo, Abar, Abaz},
-			[]A{A{}},
+			[]A{{}},
 			[]A{Afoo},
 		},
 		{
@@ -1078,7 +1138,7 @@ var jsonRoundTrips = []string{
 }
 
 var jsonNonRoundTrips = [][]string{
-	[]string{
+	{
 		"{\"foo\":8797135498471177000,\"bar\":1730933667817769214,\"baz\":13165229215395525219,\"xaz\":1316522921539552521900000000000100500}",
 		"{\"foo\":8797135498471177000,\"bar\":1730933667817769214,\"baz\":\"13165229215395525219\",\"xaz\":\"1316522921539552521900000000000100500\"}",
 	},


### PR DESCRIPTION
I was trying to roundtrip

type A struct {
     X *int64
     ...
}

and it was failing with SetInt doesnt work on Ptr

this commit adds support for this kind of roundtrip, which of course
means you can serialize { int } into { *int } and then it will not be
completely compatible. (thinking about it maybe I should make it into
a flag of the decoder)