### PR TITLE
add cleanup method to Sereal decoder Java

### DIFF
--- a/Java/sereal/src/main/java/com/booking/sereal/Decoder.java
+++ b/Java/sereal/src/main/java/com/booking/sereal/Decoder.java
@@ -908,6 +908,7 @@ public class Decoder implements SerealHeader {
   public void close() {
     if (inflater != null) {
       inflater.end();
+      inflater = null;
     }
   }
 }

--- a/Java/sereal/src/main/java/com/booking/sereal/Decoder.java
+++ b/Java/sereal/src/main/java/com/booking/sereal/Decoder.java
@@ -899,4 +899,15 @@ public class Decoder implements SerealHeader {
   private void depthDecrement() {
     recursionDepth--;
   }
+
+  /**
+   * Close the decoder to recycle the resources.
+   * <p>
+   * Returns the native memory used by inflater explicitly before the garbage collector.
+   */
+  public void close() {
+    if (inflater != null) {
+      inflater.end();
+    }
+  }
 }

--- a/Java/sereal/src/main/java/com/booking/sereal/Encoder.java
+++ b/Java/sereal/src/main/java/com/booking/sereal/Encoder.java
@@ -998,4 +998,16 @@ public class Encoder {
   private void depthDecrement() {
     recursionDepth--;
   }
+
+  /**
+   * Close the encoder to recycle the resources, it must be called by the client at the end of the
+   * use, otherwise, the behaviour is undefined when you reuse the encoder after close().
+   * <p>
+   * Returns the native memory used by deflater explicitly before the garbage collector.
+   */
+  public void close() {
+    if (deflater != null) {
+      deflater.end();
+    }
+  }
 }

--- a/Java/sereal/src/main/java/com/booking/sereal/Encoder.java
+++ b/Java/sereal/src/main/java/com/booking/sereal/Encoder.java
@@ -38,7 +38,7 @@ public class Encoder {
   private final int protocolVersion, encoding;
   private final CompressionType compressionType;
   private final long compressionThreshold;
-  private final Deflater deflater;
+  private Deflater deflater;
   private final int zstdCompressionLevel;
 
   private final int maxRecursionDepth;
@@ -1001,13 +1001,14 @@ public class Encoder {
 
   /**
    * Close the encoder to recycle the resources, it must be called by the client at the end of the
-   * use, otherwise, the behaviour is undefined when you reuse the encoder after close().
+   * use, otherwise, NullPointerException will be thrown when you reuse the ZLIB encoder.
    * <p>
    * Returns the native memory used by deflater explicitly before the garbage collector.
    */
   public void close() {
     if (deflater != null) {
       deflater.end();
+      deflater = null;
     }
   }
 }

--- a/Java/sereal/src/main/java/com/booking/sereal/TokenDecoder.java
+++ b/Java/sereal/src/main/java/com/booking/sereal/TokenDecoder.java
@@ -908,4 +908,15 @@ public class TokenDecoder {
     binaryIsUtf8 = Math.random() > 0.5;
     backreferenceOffset = (int) (Math.random() * Integer.MAX_VALUE);;
   }
+
+  /**
+   * Close the decoder to recycle the resources.
+   * <p>
+   * Returns the native memory used by inflater explicitly before the garbage collector.
+   */
+  public void close() {
+    if (inflater != null) {
+      inflater.end();
+    }
+  }
 }

--- a/Java/sereal/src/main/java/com/booking/sereal/TokenDecoder.java
+++ b/Java/sereal/src/main/java/com/booking/sereal/TokenDecoder.java
@@ -917,6 +917,7 @@ public class TokenDecoder {
   public void close() {
     if (inflater != null) {
       inflater.end();
+      inflater = null;
     }
   }
 }

--- a/Java/sereal/src/main/java/com/booking/sereal/TokenEncoder.java
+++ b/Java/sereal/src/main/java/com/booking/sereal/TokenEncoder.java
@@ -81,7 +81,7 @@ public class TokenEncoder {
   private final byte protocolVersion, encoding;
   private final CompressionType compressionType;
   private final CharsetEncoder utf8Encoder = StandardCharsets.UTF_8.newEncoder();
-  private final Deflater deflater;
+  private Deflater deflater;
   private final int compressionThreshold;
   private Context currentContext;
   private byte[] bytes = new byte[1024], compressedBytes = EMPTY_BYTE_ARRAY;
@@ -1248,13 +1248,14 @@ public class TokenEncoder {
 
   /**
    * Close the encoder to recycle the resources, it must be called by the client at the end of the
-   * use, otherwise, the behaviour is undefined when you reuse the encoder after close().
+   * use, otherwise, NullPointerException will be thrown when you reuse the ZLIB encoder.
    * <p>
    * Returns the native memory used by deflater explicitly before the garbage collector.
    */
   public void close() {
     if (deflater != null) {
       deflater.end();
+      deflater = null;
     }
   }
 }

--- a/Java/sereal/src/main/java/com/booking/sereal/TokenEncoder.java
+++ b/Java/sereal/src/main/java/com/booking/sereal/TokenEncoder.java
@@ -1245,4 +1245,16 @@ public class TokenEncoder {
       bytes[i] = (byte) (Math.random() * 256);
     }
   }
+
+  /**
+   * Close the encoder to recycle the resources, it must be called by the client at the end of the
+   * use, otherwise, the behaviour is undefined when you reuse the encoder after close().
+   * <p>
+   * Returns the native memory used by deflater explicitly before the garbage collector.
+   */
+  public void close() {
+    if (deflater != null) {
+      deflater.end();
+    }
+  }
 }

--- a/Java/sereal/src/test/java/com/booking/sereal/CompressionTest.java
+++ b/Java/sereal/src/test/java/com/booking/sereal/CompressionTest.java
@@ -113,6 +113,7 @@ public class CompressionTest {
 
 		setPaddedData(decoder, encoded);
 		assertEquals(data, decoder.decode());
+		decoder.close();
 	}
 
 	@Test
@@ -130,6 +131,7 @@ public class CompressionTest {
 
 		setPaddedData(decoder, encoded);
 		assertEquals(data, decoder.decode());
+		decoder.close();
 	}
 
 	@Test
@@ -147,6 +149,7 @@ public class CompressionTest {
 
 		setPaddedData(decoder, encoded);
 		assertEquals(data, decoder.decode());
+		decoder.close();
 	}
 
 	@Test
@@ -181,6 +184,7 @@ public class CompressionTest {
 
 		setPaddedData(decoder, encoded);
 		assertEquals(smallData, decoder.decode());
+		decoder.close();
 	}
 
 	@Test

--- a/Java/sereal/src/test/java/com/booking/sereal/EncoderTest.java
+++ b/Java/sereal/src/test/java/com/booking/sereal/EncoderTest.java
@@ -64,6 +64,7 @@ public class EncoderTest {
 		assertEquals( "Protocol version fail", 1, data[4] );
 		assertEquals( "Header suffix not 0", 0, data[5] ); // is a varint, but should be 0
 
+		encoder.close();
 	}
 
 	@Test
@@ -77,6 +78,7 @@ public class EncoderTest {
 		assertEquals( "Protocol version fail", 2, data[4] );
 		assertEquals( "Header suffix not 0", 0, data[5] ); // is a varint, but should be 0
 
+		encoder.close();
 	}
 
 	@Test
@@ -90,6 +92,7 @@ public class EncoderTest {
 		assertEquals( "Protocol version fail", 3, data[4] );
 		assertEquals( "Header suffix not 0", 0, data[5] ); // is a varint, but should be 0
 
+		encoder.close();
 	}
 
 	@Test
@@ -103,6 +106,7 @@ public class EncoderTest {
 		assertEquals( "Protocol version fail", 4, data[4] );
 		assertEquals( "Header suffix not 0", 0, data[5] ); // is a varint, but should be 0
 
+		encoder.close();
 	}
 
 	@Test
@@ -127,6 +131,7 @@ public class EncoderTest {
 		byte[] short_binary = Arrays.copyOfRange(data, 6, 10);
 		assertArrayEquals( "Short binary encoding fail", new byte[] { 0x63, 0x66, 0x6f, 0x6f }, short_binary );
 
+		encoder.close();
 	}
 
 	@Test

--- a/Java/sereal/src/test/java/com/booking/sereal/TokenEncoderTest.java
+++ b/Java/sereal/src/test/java/com/booking/sereal/TokenEncoderTest.java
@@ -484,6 +484,7 @@ public class TokenEncoderTest {
     encoder.appendLong(7);
     encoder.appendLong(8);
     encoder.endHash();
+    encoder.close();
   }
 
   @Test

--- a/Java/sereal/src/test/java/com/booking/sereal/ZipBombTest.java
+++ b/Java/sereal/src/test/java/com/booking/sereal/ZipBombTest.java
@@ -37,6 +37,7 @@ public class ZipBombTest {
         byte[] decodedData = null;
         try {
             decodedData = (byte[]) decoder.decode();
+            decoder.close();
         } catch (SerealException ex) {
             thrownException = true;
         }
@@ -157,6 +158,7 @@ public class ZipBombTest {
         byte[] decodedData = null;
         try {
             decodedData = (byte[]) decoder.decode();
+            decoder.close();
         } catch (SerealException ex) {
             thrownException = true;
             assertEquals("The uncompressed size is larger than the expected size", ex.getMessage());


### PR DESCRIPTION
Sereal decoder supports ZLIB type of inflater and it's using `java.util.zip.Inflater`, according to the implementation, the inflater is using native zlib function and will allocate native memory, the memory will be returned to the OS when the `java.util.zip.Inflater.end()` function is called or when the object is recycled by GC.
To make the memory more consistent and don't wait for the memory collection by the next time of GC, I added an explicit `public void close()` method to the decoder so the client can free the memory explicitly.