### PR TITLE
We can only "catch_violations" on perl v5.35.4 and earlier

### DIFF
--- a/Perl/shared/inc/Sereal/BuildTools.pm
+++ b/Perl/shared/inc/Sereal/BuildTools.pm
@@ -178,7 +178,14 @@ sub build_optimize {
             $gccversion= $1;
         }
 
-        if ( $catch_violations && ( $clang || $gccversion >= 4.3 ) ) {
+        if ( $] < 5.035005 && $catch_violations && ( $clang || $gccversion >= 4.3 ) ) {
+
+            # v5.35.5 enables some C99 features including mixed declarations and code,
+            # and uses them in inline.h, hence we can't enable this warning flag
+            # without generating false positive warnings.
+            # Earlier versions of perl support older compilers that are strict C89,
+            # hence we still need to avoid mixed declarations and code, hence
+            # enable this warning on earlier perls so that we can still spot problems.
 
             # -Werror= introduced in GCC 4.3
             # For trapping C++ // comments we would need -std=c89 (aka -ansi)


### PR DESCRIPTION
Perl has changed to permitting some C99 features, particularly mixed declarations and code.

For blead, adding `-Werror=declaration-after-statement` unconditionally to gcc or clang's flags will break the build. Hence only do it for v5.35.4 and earlier.

See Perl/perl5#19172