### PR TITLE
Specify how to build bundled zstd directly

### DIFF
--- a/Perl/shared/inc/Sereal/BuildTools.pm
+++ b/Perl/shared/inc/Sereal/BuildTools.pm
@@ -242,4 +242,11 @@ sub WriteMakefile {
     ExtUtils::MakeMaker::WriteMakefile(%params);
 }
 
+sub MY::postamble {
+  return <<'MAKE_FRAG';
+zstd/libzstd$(OBJ_EXT): zstd/Makefile
+	cd zstd && $(MAKE) all
+MAKE_FRAG
+}
+
 1;


### PR DESCRIPTION
This is so that it is built in the correct order when running `make` with
`MAKEFLAGS=-j$N` in order to build in parallel.

Fixes <https://github.com/Sereal/Sereal/issues/260>.
