### PR TITLE
THAW ordering fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
           - "5.30"
           - "5.32"
           - "5.34"
+          - "5.36"
         include:
           - { os: 'ubuntu-latest', perl: "5.34" , perl-threaded: true }
     steps:

--- a/Perl/Decoder/Changes
+++ b/Perl/Decoder/Changes
@@ -5,6 +5,11 @@ Revision history for Perl extension Sereal-Decoder
 *          of the decoder before upgrading to version 5 of the *
 *          encoder!                                            *
 ****************************************************************
+5.004
+    * Fix thaw ordering for frozen objects. Nested THAW operations
+      now happen in the documented LIFO order. Thanks to Marco
+      Fontani for the report.
+
 5.003
     * Production release of 5.002_001 and 5.002_002
     * OpenBSD build fixes. Gracious thanks to Andrew Hewus Fresh

--- a/Perl/Decoder/MANIFEST
+++ b/Perl/Decoder/MANIFEST
@@ -54,6 +54,7 @@ t/070_alias_options.t
 t/071_alias_reserealize.t
 t/080_set_readonly.t
 t/090_thaw.t
+t/091_thaw_order.t
 t/110_nobless.t
 t/150_dec_exception.t
 t/155_zipbomb.t

--- a/Perl/Decoder/lib/Sereal/Decoder.pm
+++ b/Perl/Decoder/lib/Sereal/Decoder.pm
@@ -5,7 +5,7 @@ use warnings;
 use Carp qw/croak/;
 use XSLoader;
 
-our $VERSION= '5.003';
+our $VERSION= '5.004';
 our $XS_VERSION= $VERSION; $VERSION= eval $VERSION;
 
 use Exporter 'import';

--- a/Perl/Decoder/lib/Sereal/Decoder/Constants.pm
+++ b/Perl/Decoder/lib/Sereal/Decoder/Constants.pm
@@ -4,7 +4,7 @@ use warnings;
 require Exporter;
 our @ISA= qw(Exporter);
 
-our $VERSION= '5.003';
+our $VERSION= '5.004';
 
 our ( @EXPORT_OK, %DEFINE, %TAG_INFO_HASH, @TAG_INFO_ARRAY );
 

--- a/Perl/Decoder/t/091_thaw_order.t
+++ b/Perl/Decoder/t/091_thaw_order.t
@@ -1,0 +1,132 @@
+#!/usr/bin/env perl
+use warnings;
+use strict;
+use File::Spec;
+use lib File::Spec->catdir(qw(t lib));
+BEGIN {
+    lib->import('lib')
+      if !-d 't';
+}
+use Test::More;
+use Sereal::TestSet qw(:all);
+use Sereal::Decoder qw(decode_sereal);
+use Data::Dumper qw(Dumper);
+
+if ( !have_encoder_and_decoder() ) {
+    plan skip_all => 'Did not find right version of encoder';
+}
+
+sub dd {
+    local $Data::Dumper::Indent = 0;
+    local $Data::Dumper::Terse = 1;
+    local $Data::Dumper::Sortkeys = 1;
+    return Data::Dumper::Dumper($_[0]);
+}
+
+my @steps;
+{
+    package FooInside;
+
+    sub new {
+        my ( $class, $attrs, @inside ) = @_;
+        $attrs ||= {};
+        return bless {
+            attrs  => { %$attrs },
+            inside => {
+                map { $_ => $inside[$_] } 0..$#inside
+            },
+        }, $class;
+    }
+
+    sub FREEZE {
+        my ( $self, $serializer ) = @_;
+
+        push @steps, 'FooInside::FREEZE(' . ::dd($self) . ')';
+        return {
+            attrs  => $self->{attrs},
+            inside => [
+                map { $self->{inside}{$_} } sort { $a <=> $b } keys %{$self->{inside}},
+            ],
+        };
+    }
+
+    sub THAW {
+        my ( $class, $serializer, @data ) = @_;
+
+        push @steps, 'FooInside::THAW(' . ::dd($data[0]) . ')';
+        return $class->new( $data[0]->{attrs}, @{ $data[0]->{inside} || [] } );
+    }
+}
+
+{
+    package FooOutside;
+
+    sub new {
+        my ( $class, $attrs, @inside ) = @_;
+        $attrs ||= {};
+        return bless {
+            attrs  => { %$attrs },
+            inside => {
+                map { $_ => $inside[$_] } 0..$#inside
+            },
+        }, $class;
+    }
+
+
+    sub FREEZE {
+        my ( $self, $serializer ) = @_;
+
+        push @steps, 'FooOutside::FREEZE(' . ::dd($self) . ')';
+        return {
+            attrs  => $self->{attrs},
+            inside => [
+                map { $self->{inside}{$_} } sort { $a <=> $b } keys %{$self->{inside}},
+            ],
+        };
+    }
+
+    sub THAW {
+        my ( $class, $serializer, @data ) = @_;
+
+        push @steps, 'FooOutside::THAW(' . ::dd($data[0]) . ')';
+        return $class->new( $data[0]->{attrs}, @{ $data[0]->{inside} || [] } );
+    }
+}
+
+my $struct = 
+    FooOutside->new(
+        # Attrs
+        {
+            attr1 => 'foobar',
+            bar => FooInside->new({}, 'should_be_first'),
+        },
+        FooInside->new({}, 'second/not_frozen', 'third/not_frozen'),
+        FooOutside->new({}, FooInside->new({}, 'fourth/inner')),
+    );
+
+my $srl = Sereal::Encoder::encode_sereal($struct, { freeze_callbacks => 1, canonical => 1 });
+my $dec = decode_sereal($srl);
+
+
+is_deeply(\@steps, [
+          "FooOutside::FREEZE(bless( {'attrs' => {'attr1' => 'foobar','bar' => bless( {'attrs' => {},'inside' => {'0' => 'should_be_first'}}, 'FooInside' )},'inside' => {'0' => bless( {'attrs' => {},'inside' => {'0' => 'second/not_frozen','1' => 'third/not_frozen'}}, 'FooInside' ),'1' => bless( {'attrs' => {},'inside' => {'0' => bless( {'attrs' => {},'inside' => {'0' => 'fourth/inner'}}, 'FooInside' )}}, 'FooOutside' )}}, 'FooOutside' ))",
+          "FooInside::FREEZE(bless( {'attrs' => {},'inside' => {'0' => 'should_be_first'}}, 'FooInside' ))",
+          "FooInside::FREEZE(bless( {'attrs' => {},'inside' => {'0' => 'second/not_frozen','1' => 'third/not_frozen'}}, 'FooInside' ))",
+          "FooOutside::FREEZE(bless( {'attrs' => {},'inside' => {'0' => bless( {'attrs' => {},'inside' => {'0' => 'fourth/inner'}}, 'FooInside' )}}, 'FooOutside' ))",
+          "FooInside::FREEZE(bless( {'attrs' => {},'inside' => {'0' => 'fourth/inner'}}, 'FooInside' ))",
+          "FooInside::THAW({'attrs' => {},'inside' => ['fourth/inner']})",
+          "FooOutside::THAW({'attrs' => {},'inside' => [bless( {'attrs' => {},'inside' => {'0' => 'fourth/inner'}}, 'FooInside' )]})",
+          "FooInside::THAW({'attrs' => {},'inside' => ['second/not_frozen','third/not_frozen']})",
+          "FooInside::THAW({'attrs' => {},'inside' => ['should_be_first']})",
+          "FooOutside::THAW({'attrs' => {'attr1' => 'foobar','bar' => bless( {'attrs' => {},'inside' => {'0' => 'should_be_first'}}, 'FooInside' )},'inside' => [bless( {'attrs' => {},'inside' => {'0' => 'second/not_frozen','1' => 'third/not_frozen'}}, 'FooInside' ),bless( {'attrs' => {},'inside' => {'0' => bless( {'attrs' => {},'inside' => {'0' => 'fourth/inner'}}, 'FooInside' )}}, 'FooOutside' )]})"
+        ], "freeze/thaw sequence for nested objects was as expected") or do {
+    if ($ENV{DUMP_STEPS}) {
+        local $Data::Dumper::Useqq = 1;
+        print Dumper(\@steps),"\n";
+    }
+};
+
+is_deeply( $dec, $struct, "And the final structures match according to is_deeply()");
+is( dd($dec), dd($struct), "And the final structures match according to Dumper");
+
+done_testing;

--- a/Perl/Encoder/Changes
+++ b/Perl/Encoder/Changes
@@ -5,6 +5,11 @@ Revision history for Perl extension Sereal-Encoder
 *          of the decoder before upgrading to version 5 of the *
 *          encoder!                                            *
 ****************************************************************
+5.004
+    * Decoder fixes: Fix thaw ordering for frozen objects. Nested THAW
+      operations now happen in the documented LIFO order. Thanks to Marco 
+      Fontani for the report.
+
 5.003
     * Production release of 5.002_001 and 5.002_002
     * OpenBSD build fixes. Gracious thanks to Andrew Hewus Fresh

--- a/Perl/Encoder/Makefile.PL
+++ b/Perl/Encoder/Makefile.PL
@@ -6,7 +6,7 @@ use warnings;
 use ExtUtils::MakeMaker;
 use Config;
 
-our $VERSION= '5.003'; # what version are we and what version of Decoder do we need.
+our $VERSION= '5.004'; # what version are we and what version of Decoder do we need.
 $VERSION = eval $VERSION or die "WTF: $VERSION: $@"; # deal with underbars
 
 my $shared_dir= "../shared";

--- a/Perl/Encoder/lib/Sereal/Encoder.pm
+++ b/Perl/Encoder/lib/Sereal/Encoder.pm
@@ -5,7 +5,7 @@ use warnings;
 use Carp qw/croak/;
 use XSLoader;
 
-our $VERSION= '5.003';
+our $VERSION= '5.004';
 our $XS_VERSION= $VERSION; $VERSION= eval $VERSION;
 
 # Make sure to keep these constants in sync with the C code in srl_encoder.c.

--- a/Perl/Encoder/lib/Sereal/Encoder/Constants.pm
+++ b/Perl/Encoder/lib/Sereal/Encoder/Constants.pm
@@ -4,7 +4,7 @@ use warnings;
 require Exporter;
 our @ISA= qw(Exporter);
 
-our $VERSION= '5.003';
+our $VERSION= '5.004';
 
 our ( @EXPORT_OK, %DEFINE, %TAG_INFO_HASH, @TAG_INFO_ARRAY );
 

--- a/Perl/Sereal/Changes
+++ b/Perl/Sereal/Changes
@@ -13,6 +13,11 @@ from the the Encoder and Decoder changelogs:
 *          Sereal package and instead install the Encoder or   *
 *          Decoder independently.                              *
 ****************************************************************
+5.004
+    * Decoder fixes: Fix thaw ordering for frozen objects. Nested THAW
+      operations now happen in the documented LIFO order. Thanks to Marco 
+      Fontani for the report.
+
 5.003
     * Production release of 5.002_001 and 5.002_002
     * OpenBSD build fixes. Gracious thanks to Andrew Hewus Fresh

--- a/Perl/Sereal/Makefile.PL
+++ b/Perl/Sereal/Makefile.PL
@@ -4,7 +4,7 @@ use warnings;
 
 use ExtUtils::MakeMaker;
 use Cwd;
-our $VERSION= '5.003';
+our $VERSION= '5.004';
 $VERSION = eval $VERSION or die "WTF: $VERSION: $@"; # deal with underbars
 
 my $shared_dir= "../shared";

--- a/Perl/Sereal/lib/Sereal.pm
+++ b/Perl/Sereal/lib/Sereal.pm
@@ -2,9 +2,9 @@ package Sereal;
 use 5.008;
 use strict;
 use warnings;
-our $VERSION= '5.003';
+our $VERSION= '5.004';
 our $XS_VERSION= $VERSION; $VERSION= eval $VERSION;
-use Sereal::Encoder 5.003 qw(
+use Sereal::Encoder 5.004 qw(
     encode_sereal
     sereal_encode_with_object
     SRL_UNCOMPRESSED
@@ -12,7 +12,7 @@ use Sereal::Encoder 5.003 qw(
     SRL_ZLIB
     SRL_ZSTD
 );
-use Sereal::Decoder 5.003 qw(
+use Sereal::Decoder 5.004 qw(
     decode_sereal
     looks_like_sereal
     decode_sereal_with_header_data


### PR DESCRIPTION
Currently we aren't THAWing in LIFO order, we are doing it in FIFO order, which isnt correct, if A contains B and both need to be THAWed we should THAW B first, then A.

Fixes #283