### PR TITLE
hobodecoder.pl: support SRL_PROTOCOL_ENCODING_ZSTD

### DIFF
--- a/Perl/shared/author_tools/hobodecoder.pl
+++ b/Perl/shared/author_tools/hobodecoder.pl
@@ -106,6 +106,13 @@ sub parse_header {
         my $out= Compress::Zlib::uncompress($data);
         $data= $out;
     }
+    elsif ( $encoding == SRL_PROTOCOL_ENCODING_ZSTD ) {
+        print "Header says: Document body is ZSTD-compressed.\n";
+        my $compressed_len= varint();
+        require Compress::Zstd;
+        my $out= Compress::Zstd::decompress($data);
+        $data= $out;
+    }
     else {
         die "Invalid encoding '" . ( $encoding >> SRL_PROTOCOL_VERSION_BITS ) . "'";
     }


### PR DESCRIPTION
... which wasn't yet supported by it.

This is the modification I'd done a while back when looking into why Sereal wasn't properly doing FREEZE/THAW of some structures.

Might as well have them in the repo, so that if anyone else is using ZSTD compression, the tool will work for them, too.