### PR TITLE
fix error in docs: default encoding protocol is 5, not 4

### DIFF
--- a/Perl/Encoder/lib/Sereal/Encoder.pm
+++ b/Perl/Encoder/lib/Sereal/Encoder.pm
@@ -153,7 +153,7 @@ If you care greatly about performance, consider reading the L<Sereal::Performanc
 documentation after finishing this document.
 
 The Sereal protocol version emitted by this encoder implementation is currently
-protocol version 4 by default.
+protocol version 5 by default.
 
 The protocol specification and many other bits of documentation
 can be found in the github repository. Right now, the specification is at


### PR DESCRIPTION
This bit me:  I upgraded *some* machines to new Sereal thinking the new version was still emitting v4, but it was emitting v5, meaning parts of the cluster couldn't share data.  Oops!

Possibly this change can be made more timeless, like "the default protocol will match the major version number of this module", but I don't know!  But this at least makes it factually correct.