### PR TITLE
Allow Thaw scalar to return a non reference value

### DIFF
--- a/Perl/Decoder/srl_decoder.c
+++ b/Perl/Decoder/srl_decoder.c
@@ -1740,9 +1740,13 @@ srl_thaw_object(pTHX_ srl_decoder_t *dec, HV *class_stash, SV *into)
     }
     SvREFCNT_dec(arg_av);
 
-    if (SvROK(replacement)) {
-        SvRV_set(into,  SvRV(replacement));
-        SvREFCNT_inc(SvRV(replacement));
+    if (replacement != NULL) {
+        if (SvROK(replacement)) {
+            SvRV_set(into,  SvRV(replacement));
+            SvREFCNT_inc(SvRV(replacement));
+        } else {
+            sv_setsv(into, newSVsv(replacement));
+        }
         SvREFCNT_dec(replacement);
     } else {
         SvRV_set(into, newSV(0));

--- a/Perl/Decoder/srl_decoder.c
+++ b/Perl/Decoder/srl_decoder.c
@@ -1654,7 +1654,6 @@ SRL_STATIC_INLINE void
 srl_read_frozen_object(pTHX_ srl_decoder_t *dec, HV *class_stash, SV *into)
 {
 
-    AV *info_av;
     if (!dec->thaw_av)
         SAFE_NEW_AV(dec->thaw_av);
 

--- a/Perl/Decoder/t/092_thaw_scalar.t
+++ b/Perl/Decoder/t/092_thaw_scalar.t
@@ -1,0 +1,61 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use File::Spec;
+use lib File::Spec->catdir(qw(t lib));
+
+BEGIN {
+    lib->import('lib')
+      if !-d 't';
+}
+use Test::More;
+use Sereal::TestSet qw(:all);
+use Sereal::Decoder qw(decode_sereal);
+use Data::Dumper;
+
+if ( !have_encoder_and_decoder() ) {
+    plan skip_all => 'Did not find right version of encoder';
+}
+
+{
+
+    package Rot13;
+
+    sub rot13 {
+        my ($d) = @_;
+        $d =~ tr/a-zA-Z/nopqrstuvwxyzabcdefghijklmNOPQRSTUVWXYZABCDEFGHIJKLM/;
+        return $d;
+    }
+
+    sub new {
+        my ( $class, $secret ) = @_;
+        bless \$secret, $class;
+    }
+
+    sub FREEZE {
+        my ( $self, $serializer ) = @_;
+        return rot13($$self);
+    }
+
+    sub THAW {
+        my ( $class, $serializer, $data ) = @_;
+        return rot13($data);
+    }
+}
+
+my $encoder_freeze = Sereal::Encoder->new( { freeze_callbacks => 1 } );
+
+my $secret = "SECRET";
+
+ok(
+    $secret,
+    decode_sereal($encoder_freeze->encode(Rot13->new($secret))),
+);
+
+ok(
+    { secret => $secret },
+    decode_sereal($encoder_freeze->encode({ secret => Rot13->new($secret) })),
+);
+
+done_testing;


### PR DESCRIPTION
At the moment when THAW returns a non ref value it will become `\undef`.
This patch will respect what is returned by THAW.

```perl
#!/bin/perl
use Sereal qw(decode_sereal);
{

    package Rot13;

    sub rot13 {
        my ($d) = @_;
        $d =~ tr/a-zA-Z/nopqrstuvwxyzabcdefghijklmNOPQRSTUVWXYZABCDEFGHIJKLM/;
        return $d;
    }

    sub new {
        my ( $class, $secret ) = @_;
        bless \$secret, $class;
    }

    sub FREEZE {
        my ( $self, $serializer ) = @_;
        return rot13($$self);
    }

    sub THAW {
        my ( $class, $serializer, $data ) = @_;
        return rot13($data);
    }
}


my $encoder_freeze = Sereal::Encoder->new( { freeze_callbacks => 1 } );

my $secret = "SECRET";

if (decode_sereal($encoder_freeze->encode(Rot13->new($secret))) eq $secret) {
  print "You did it\n"
}
```